### PR TITLE
Package creation for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 100
+        filter: tree:0
     - uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.0.x'

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -6,6 +6,8 @@
     <EntityFrameworkVersion>8.0.4</EntityFrameworkVersion>
     
     <IdentityServerVersion>4.8.0-*</IdentityServerVersion>
+
+    <MinVerTagPrefix>v</MinVerTagPrefix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Packages aren't created properly due to the fact that release tags are prefixed with `v`.

Use MinVer tag prefix 'v'