### PR TITLE
Set fetch-depth to 0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 100
+        fetch-depth: 0
         filter: tree:0
     - uses: actions/setup-dotnet@v4
       with:


### PR DESCRIPTION
If the history doesn't contain a version tag then the package IDs are incorrect.
