### PR TITLE
Update to .NET 10.0.2

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "dotnet-ef": {
-      "version": "8.0.10",
+      "version": "10.0.2",
       "commands": [
         "dotnet-ef"
       ]

--- a/.editorconfig
+++ b/.editorconfig
@@ -1923,6 +1923,9 @@ resharper_x_unit2019_highlighting=none
 resharper_x_unit3000_highlighting=error
 resharper_x_unit3001_highlighting=error
 
+# XUnit
+dotnet_diagnostic.xUnit1051.severity = none
+
 [{*.har,*.jsb2,*.jsb3,*.json,.babelrc,.eslintrc,.stylelintrc,bowerrc,jest.config}]
 indent_style=space
 indent_size=2

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "10.0.102",
     "rollForward": "latestMajor"
   }
 }

--- a/src/AspNetIdentity/build/build.csproj
+++ b/src/AspNetIdentity/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AspNetIdentity/host/Configuration/Resources.cs
+++ b/src/AspNetIdentity/host/Configuration/Resources.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Models;
 using System.Collections.Generic;
 using static IdentityServer4.IdentityServerConstants;

--- a/src/AspNetIdentity/host/Host.csproj
+++ b/src/AspNetIdentity/host/Host.csproj
@@ -1,20 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
-    <PackageReference Include="System.Security.Principal.Windows" />
     
     <ProjectReference Include="..\src\IdentityServer4.AspNetIdentity.csproj" />
   </ItemGroup>

--- a/src/AspNetIdentity/host/Quickstart/Account/AccountController.cs
+++ b/src/AspNetIdentity/host/Quickstart/Account/AccountController.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4;
 using IdentityServer4.Events;
 using IdentityServer4.Extensions;

--- a/src/AspNetIdentity/host/Quickstart/Account/ExternalController.cs
+++ b/src/AspNetIdentity/host/Quickstart/Account/ExternalController.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4;
 using IdentityServer4.Events;
 using IdentityServer4.Models;

--- a/src/AspNetIdentity/host/Quickstart/Diagnostics/DiagnosticsViewModel.cs
+++ b/src/AspNetIdentity/host/Quickstart/Diagnostics/DiagnosticsViewModel.cs
@@ -4,9 +4,9 @@
 
 using IdentityModel;
 using Microsoft.AspNetCore.Authentication;
-using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Text;
+using System.Text.Json;
 
 namespace IdentityServerHost.Quickstart.UI
 {
@@ -22,7 +22,7 @@ namespace IdentityServerHost.Quickstart.UI
                 var bytes = Base64Url.Decode(encoded);
                 var value = Encoding.UTF8.GetString(bytes);
 
-                Clients = JsonConvert.DeserializeObject<string[]>(value);
+                Clients = JsonSerializer.Deserialize<string[]>(value);
             }
         }
 

--- a/src/AspNetIdentity/host/Quickstart/Diagnostics/DiagnosticsViewModel.cs
+++ b/src/AspNetIdentity/host/Quickstart/Diagnostics/DiagnosticsViewModel.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using System.Buffers.Text;
 using Microsoft.AspNetCore.Authentication;
 using System.Collections.Generic;
 using System.Text;
@@ -19,7 +19,7 @@ namespace IdentityServerHost.Quickstart.UI
             if (result.Properties.Items.ContainsKey("client_list"))
             {
                 var encoded = result.Properties.Items["client_list"];
-                var bytes = Base64Url.Decode(encoded);
+                var bytes = Base64Url.DecodeFromChars(encoded);
                 var value = Encoding.UTF8.GetString(bytes);
 
                 Clients = JsonSerializer.Deserialize<string[]>(value);

--- a/src/AspNetIdentity/host/Quickstart/TestUsers.cs
+++ b/src/AspNetIdentity/host/Quickstart/TestUsers.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Test;
 using System.Collections.Generic;
 using System.Security.Claims;

--- a/src/AspNetIdentity/migrations/SqlServer/Program.cs
+++ b/src/AspNetIdentity/migrations/SqlServer/Program.cs
@@ -1,20 +1,28 @@
-﻿using IdentityServerHost;
-using Microsoft.AspNetCore;
+using System.Threading.Tasks;
+using IdentityServerHost;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 
 namespace SqlServer
 {
     class Program
     {
-        public static void Main(string[] args)
+        public static async Task Main(string[] args)
         {
             var host = BuildWebHost(args);
+            await host.StartAsync();
             SeedData.EnsureSeedData(host.Services);
+            await host.StopAsync();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
+        public static IHost BuildWebHost(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                        .UseStartup<Startup>()
+                        .UseKestrel();
+                })
                 .Build();
     }
 }

--- a/src/AspNetIdentity/migrations/SqlServer/SeedData.cs
+++ b/src/AspNetIdentity/migrations/SqlServer/SeedData.cs
@@ -6,7 +6,7 @@ using System;
 using System.Linq;
 using System.Security.Claims;
 using IdentityServerHost.Data;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Models;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;

--- a/src/AspNetIdentity/migrations/SqlServer/SqlServer.csproj
+++ b/src/AspNetIdentity/migrations/SqlServer/SqlServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AspNetIdentity/src/IdentityServer4.AspNetIdentity.csproj
+++ b/src/AspNetIdentity/src/IdentityServer4.AspNetIdentity.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>IdentityServer4.NET.AspNetIdentity</PackageId>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     
     <Description>ASP.NET Core Identity Integration for IdentityServer4</Description>
     <Authors>Sparkling Logic</Authors>

--- a/src/AspNetIdentity/src/IdentityServerBuilderExtensions.cs
+++ b/src/AspNetIdentity/src/IdentityServerBuilderExtensions.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Linq;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4;
 using IdentityServer4.AspNetIdentity;
 using IdentityServer4.Configuration;

--- a/src/AspNetIdentity/src/ResourceOwnerPasswordValidator.cs
+++ b/src/AspNetIdentity/src/ResourceOwnerPasswordValidator.cs
@@ -7,7 +7,7 @@ using IdentityServer4.Validation;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
-using static IdentityModel.OidcConstants;
+using static Duende.IdentityModel.OidcConstants;
 using IdentityServer4.Services;
 using IdentityServer4.Events;
 

--- a/src/AspNetIdentity/src/UserClaimsFactory.cs
+++ b/src/AspNetIdentity/src/UserClaimsFactory.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using System.Security.Claims;
-using IdentityModel;
+using Duende.IdentityModel;
 
 namespace IdentityServer4.AspNetIdentity
 {

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,27 +1,27 @@
 <Project>
 
   <PropertyGroup>
-    <FrameworkVersion>8.0.10</FrameworkVersion>
-    <ExtensionsVersion>8.0.10</ExtensionsVersion>
-    <EntityFrameworkVersion>8.0.10</EntityFrameworkVersion>
+    <FrameworkVersion>10.0.2</FrameworkVersion>
+    <ExtensionsVersion>10.0.2</ExtensionsVersion>
+    <EntityFrameworkVersion>10.0.2</EntityFrameworkVersion>
     
-    <IdentityServerVersion>4.8.0-*</IdentityServerVersion>
+    <IdentityServerVersion>4.10.0-*</IdentityServerVersion>
 
     <MinVerTagPrefix>v</MinVerTagPrefix>
   </PropertyGroup>
 
   <ItemGroup>
     <!--build related-->
-    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All" />
-    <PackageReference Update="SimpleExec" Version="12.0.0" />
-    <PackageReference Update="Bullseye" Version="5.0.0" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
+    <PackageReference Update="SimpleExec" Version="13.0.0" />
+    <PackageReference Update="Bullseye" Version="6.1.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.102" PrivateAssets="All" />
 
     <!--tests -->
-    <PackageReference Update="FluentAssertions" Version="6.12.1" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Update="xunit" Version="2.9.2" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="All" />
+    <PackageReference Update="FluentAssertions" Version="8.8.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Update="xunit.v3" Version="3.2.2" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="All" />
 
     <!--our stuff -->
     <PackageReference Update="IdentityModel" Version="7.0.0" />
@@ -35,10 +35,10 @@
     <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(ExtensionsVersion)" />
     
     <!--misc -->
-    <PackageReference Update="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.2.0" />
-    <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="8.2.0" />
-    <PackageReference Update="System.Security.Principal.Windows" Version="5.0.0" />
-    <PackageReference Update="AutoMapper" Version="13.0.1" />
+    <PackageReference Update="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.15.0" />
+    <PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
+    <!-- PackageReference Update="System.Security.Principal.Windows" Version="5.0.0" / -->
+    <PackageReference Update="AutoMapper" Version="16.0.0" />
     
     <!--microsoft asp.net core -->
     <PackageReference Update="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(FrameworkVersion)" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -24,7 +24,7 @@
     <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="All" />
 
     <!--our stuff -->
-    <PackageReference Update="IdentityModel" Version="7.0.0" />
+    <PackageReference Update="Duende.IdentityModel" Version="8.0.0" />
 
     <!--microsoft extensions -->
     <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="$(ExtensionsVersion)" />

--- a/src/EntityFramework.Storage/build/build.csproj
+++ b/src/EntityFramework.Storage/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EntityFramework.Storage/host/ConsoleHost/ConsoleHost.csproj
+++ b/src/EntityFramework.Storage/host/ConsoleHost/ConsoleHost.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EntityFramework.Storage/migrations/SqlServer/Program.cs
+++ b/src/EntityFramework.Storage/migrations/SqlServer/Program.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.AspNetCore;
+using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 
 namespace SqlServer
 {
@@ -9,9 +10,14 @@ namespace SqlServer
         {
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
+        public static IHost BuildWebHost(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                        .UseStartup<Startup>()
+                        .UseKestrel();
+                })
                 .Build();
     }
 }

--- a/src/EntityFramework.Storage/migrations/SqlServer/SqlServer.csproj
+++ b/src/EntityFramework.Storage/migrations/SqlServer/SqlServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EntityFramework.Storage/src/IdentityServer4.EntityFramework.Storage.csproj
+++ b/src/EntityFramework.Storage/src/IdentityServer4.EntityFramework.Storage.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>IdentityServer4.NET.EntityFramework.Storage</PackageId>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     
     <Description>EntityFramework persistence layer for IdentityServer4</Description>
     <Authors>Sparkling Logic</Authors>

--- a/src/EntityFramework.Storage/src/Mappers/ApiResourceMappers.cs
+++ b/src/EntityFramework.Storage/src/Mappers/ApiResourceMappers.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using AutoMapper;
 using IdentityServer4.EntityFramework.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace IdentityServer4.EntityFramework.Mappers
 {
@@ -14,7 +15,7 @@ namespace IdentityServer4.EntityFramework.Mappers
     {
         static ApiResourceMappers()
         {
-            Mapper = new MapperConfiguration(cfg => cfg.AddProfile<ApiResourceMapperProfile>())
+            Mapper = new MapperConfiguration(cfg => cfg.AddProfile<ApiResourceMapperProfile>(), new NullLoggerFactory())
                 .CreateMapper();
         }
 

--- a/src/EntityFramework.Storage/src/Mappers/ClientMappers.cs
+++ b/src/EntityFramework.Storage/src/Mappers/ClientMappers.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using AutoMapper;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace IdentityServer4.EntityFramework.Mappers
 {
@@ -13,7 +14,7 @@ namespace IdentityServer4.EntityFramework.Mappers
     {
         static ClientMappers()
         {
-            Mapper = new MapperConfiguration(cfg => cfg.AddProfile<ClientMapperProfile>())
+            Mapper = new MapperConfiguration(cfg => cfg.AddProfile<ClientMapperProfile>(), new NullLoggerFactory())
                 .CreateMapper();
         }
 

--- a/src/EntityFramework.Storage/src/Mappers/IdentityResourceMappers.cs
+++ b/src/EntityFramework.Storage/src/Mappers/IdentityResourceMappers.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using AutoMapper;
 using IdentityServer4.EntityFramework.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace IdentityServer4.EntityFramework.Mappers
 {
@@ -14,7 +15,7 @@ namespace IdentityServer4.EntityFramework.Mappers
     {
         static IdentityResourceMappers()
         {
-            Mapper = new MapperConfiguration(cfg => cfg.AddProfile<IdentityResourceMapperProfile>())
+            Mapper = new MapperConfiguration(cfg => cfg.AddProfile<IdentityResourceMapperProfile>(), new NullLoggerFactory())
                 .CreateMapper();
         }
 

--- a/src/EntityFramework.Storage/src/Mappers/PersistedGrantMappers.cs
+++ b/src/EntityFramework.Storage/src/Mappers/PersistedGrantMappers.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using AutoMapper;
 using IdentityServer4.Models;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace IdentityServer4.EntityFramework.Mappers
 {
@@ -14,7 +15,7 @@ namespace IdentityServer4.EntityFramework.Mappers
     {
         static PersistedGrantMappers()
         {
-            Mapper = new MapperConfiguration(cfg =>cfg.AddProfile<PersistedGrantMapperProfile>())
+            Mapper = new MapperConfiguration(cfg =>cfg.AddProfile<PersistedGrantMapperProfile>(), new NullLoggerFactory())
                 .CreateMapper();
         }
 

--- a/src/EntityFramework.Storage/src/Mappers/ScopeMappers.cs
+++ b/src/EntityFramework.Storage/src/Mappers/ScopeMappers.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using AutoMapper;
 using IdentityServer4.EntityFramework.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace IdentityServer4.EntityFramework.Mappers
 {
@@ -14,7 +15,7 @@ namespace IdentityServer4.EntityFramework.Mappers
     {
         static ScopeMappers()
         {
-            Mapper = new MapperConfiguration(cfg => cfg.AddProfile<ScopeMapperProfile>())
+            Mapper = new MapperConfiguration(cfg => cfg.AddProfile<ScopeMapperProfile>(), new NullLoggerFactory())
                 .CreateMapper();
         }
 

--- a/src/EntityFramework.Storage/src/Stores/DeviceFlowStore.cs
+++ b/src/EntityFramework.Storage/src/Stores/DeviceFlowStore.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.EntityFramework.Entities;
 using IdentityServer4.EntityFramework.Interfaces;
 using IdentityServer4.Models;

--- a/src/EntityFramework.Storage/test/IntegrationTests/DbContexts/ClientDbContextTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/DbContexts/ClientDbContextTests.cs
@@ -15,7 +15,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.DbContexts
     {
         public ClientDbContextTests(DatabaseProviderFixture<ConfigurationDbContext> fixture) : base(fixture)
         {
-            foreach (var options in ((TheoryData)TestDatabaseProviders).SelectMany(x => x.Select(y => (DbContextOptions<ConfigurationDbContext>)y)).ToList())
+            foreach (var options in TestDatabaseProviders.Select(x => x.Data).ToList())
             {
                 using (var context = new ConfigurationDbContext(options, StoreOptions))
                     context.Database.EnsureCreated();

--- a/src/EntityFramework.Storage/test/IntegrationTests/IdentityServer4.EntityFramework.IntegrationTests.csproj
+++ b/src/EntityFramework.Storage/test/IntegrationTests/IdentityServer4.EntityFramework.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <AssemblyOriginatorKeyFile>../../../../key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -21,7 +21,7 @@
   <ItemGroup>
     
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FluentAssertions" />
     

--- a/src/EntityFramework.Storage/test/IntegrationTests/IntegrationTest.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/IntegrationTest.cs
@@ -17,7 +17,8 @@ namespace IdentityServer4.EntityFramework.IntegrationTests
     public class IntegrationTest<TClass, TDbContext, TStoreOption> : IClassFixture<DatabaseProviderFixture<TDbContext>>
         where TDbContext : DbContext
     {
-        public static readonly TheoryData<DbContextOptions<TDbContext>> TestDatabaseProviders;
+        public static readonly TheoryData<DbContextOptions<TDbContext>> Providers;
+        public static TheoryData<DbContextOptions<TDbContext>> TestDatabaseProviders => Providers;
         protected readonly TStoreOption StoreOptions = Activator.CreateInstance<TStoreOption>();
 
         static IntegrationTest()
@@ -30,7 +31,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests
             {
                 Console.WriteLine($"Running Local Tests for {typeof(TClass).Name}");
 
-                TestDatabaseProviders = new TheoryData<DbContextOptions<TDbContext>>
+                Providers = new TheoryData<DbContextOptions<TDbContext>>
                 {
                     DatabaseProviderBuilder.BuildInMemory<TDbContext>(typeof(TClass).Name),
                     //DatabaseProviderBuilder.BuildSqlite<TDbContext>(typeof(TClass).Name),
@@ -39,7 +40,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests
             }
             else
             {
-                TestDatabaseProviders = new TheoryData<DbContextOptions<TDbContext>>
+                Providers = new TheoryData<DbContextOptions<TDbContext>>
                 {
                     DatabaseProviderBuilder.BuildInMemory<TDbContext>(typeof(TClass).Name),
                     DatabaseProviderBuilder.BuildSqlite<TDbContext>(typeof(TClass).Name)

--- a/src/EntityFramework.Storage/test/IntegrationTests/IntegrationTest.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/IntegrationTest.cs
@@ -50,7 +50,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests
 
         protected IntegrationTest(DatabaseProviderFixture<TDbContext> fixture)
         {
-            fixture.Options = ((TheoryData) TestDatabaseProviders).SelectMany(x => x.Select(y => (DbContextOptions<TDbContext>)y)).ToList();
+            fixture.Options =TestDatabaseProviders.Select(x => x.Data).ToList();
             fixture.StoreOptions = StoreOptions;
         }
     }

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/ClientStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/ClientStoreTests.cs
@@ -21,7 +21,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
     {
         public ClientStoreTests(DatabaseProviderFixture<ConfigurationDbContext> fixture) : base(fixture)
         {
-            foreach (var options in ((TheoryData)TestDatabaseProviders).SelectMany(x => x.Select(y => (DbContextOptions<ConfigurationDbContext>) y)).ToList())
+            foreach (var options in TestDatabaseProviders.Select(x => x.Data).ToList())
             {
                 using (var context = new ConfigurationDbContext(options, StoreOptions))
                 {
@@ -155,7 +155,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
                 }
                 else
                 {
-                    throw new TestTimeoutException(timeout);
+                    throw TestTimeoutException.ForTimedOutTest(timeout);
                 }
             }
         }

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/DeviceFlowStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/DeviceFlowStoreTests.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.EntityFramework.Entities;
 using Microsoft.EntityFrameworkCore.InMemory.Infrastructure.Internal;
 using Xunit;

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/DeviceFlowStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/DeviceFlowStoreTests.cs
@@ -123,12 +123,14 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             {
                 var store = new DeviceFlowStore(context, new PersistentGrantSerializer(), FakeLogger<DeviceFlowStore>.Create());
 
+#pragma warning disable EF1001 // Suppress internal EF Core API usage warning
                 // skip odd behaviour of in-memory provider
                 if (options.Extensions.All(x => x.GetType() != typeof(InMemoryOptionsExtension)))
                 {
                     await Assert.ThrowsAsync<DbUpdateException>(() =>
                         store.StoreDeviceAuthorizationAsync($"device_{Guid.NewGuid().ToString()}", existingUserCode, deviceCodeData));
                 }
+#pragma warning restore EF1001
             }
         }
 
@@ -165,13 +167,14 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
                 var store = new DeviceFlowStore(context, new PersistentGrantSerializer(), FakeLogger<DeviceFlowStore>.Create());
-
+#pragma warning disable EF1001 // Suppress internal EF Core API usage warning
                 // skip odd behaviour of in-memory provider
                 if (options.Extensions.All(x => x.GetType() != typeof(InMemoryOptionsExtension)))
                 {
                     await Assert.ThrowsAsync<DbUpdateException>(() =>
                         store.StoreDeviceAuthorizationAsync(existingDeviceCode, $"user_{Guid.NewGuid().ToString()}", deviceCodeData));
                 }
+#pragma warning restore EF1001
             }
         }
 

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/DeviceFlowStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/DeviceFlowStoreTests.cs
@@ -23,7 +23,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
 
         public DeviceFlowStoreTests(DatabaseProviderFixture<PersistedGrantDbContext> fixture) : base(fixture)
         {
-            foreach (var options in ((TheoryData)TestDatabaseProviders).SelectMany(x => x.Select(y => (DbContextOptions<PersistedGrantDbContext>)y)).ToList())
+            foreach (var options in TestDatabaseProviders.Select(x => x.Data).ToList())
             {
                 using (var context = new PersistedGrantDbContext(options, StoreOptions))
                     context.Database.EnsureCreated();

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/PersistedGrantStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/PersistedGrantStoreTests.cs
@@ -19,11 +19,12 @@ using Xunit;
 
 namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
 {
+    [Collection("Sequential")]
     public class PersistedGrantStoreTests : IntegrationTest<PersistedGrantStoreTests, PersistedGrantDbContext, OperationalStoreOptions>
     {
         public PersistedGrantStoreTests(DatabaseProviderFixture<PersistedGrantDbContext> fixture) : base(fixture)
         {
-            foreach (var options in ((TheoryData)TestDatabaseProviders).SelectMany(x => x.Select(y => (DbContextOptions<PersistedGrantDbContext>)y)).ToList())
+            foreach (var options in TestDatabaseProviders.Select(x => x.Data).ToList())
             {
                 using (var context = new PersistedGrantDbContext(options, StoreOptions))
                     context.Database.EnsureCreated();

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/PersistedGrantStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/PersistedGrantStoreTests.cs
@@ -112,15 +112,15 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
         {
             using (var context = new PersistedGrantDbContext(options, StoreOptions))
             {
-                context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c1", sid: "s1", type: "t1").ToEntity());
-                context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c1", sid: "s1", type: "t2").ToEntity());
-                context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c1", sid: "s2", type: "t1").ToEntity());
-                context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c1", sid: "s2", type: "t2").ToEntity());
-                context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c2", sid: "s1", type: "t1").ToEntity());
-                context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c2", sid: "s1", type: "t2").ToEntity());
-                context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c2", sid: "s2", type: "t1").ToEntity());
-                context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c2", sid: "s2", type: "t2").ToEntity());
-                context.PersistedGrants.Add(CreateTestObject(sub: "sub1", clientId: "c3", sid: "s3", type: "t3").ToEntity());
+                context.PersistedGrants.Add(CreateTestObject(sub: "sub4", clientId: "c1", sid: "s1", type: "t1").ToEntity());
+                context.PersistedGrants.Add(CreateTestObject(sub: "sub4", clientId: "c1", sid: "s1", type: "t2").ToEntity());
+                context.PersistedGrants.Add(CreateTestObject(sub: "sub4", clientId: "c1", sid: "s2", type: "t1").ToEntity());
+                context.PersistedGrants.Add(CreateTestObject(sub: "sub4", clientId: "c1", sid: "s2", type: "t2").ToEntity());
+                context.PersistedGrants.Add(CreateTestObject(sub: "sub4", clientId: "c2", sid: "s1", type: "t1").ToEntity());
+                context.PersistedGrants.Add(CreateTestObject(sub: "sub4", clientId: "c2", sid: "s1", type: "t2").ToEntity());
+                context.PersistedGrants.Add(CreateTestObject(sub: "sub4", clientId: "c2", sid: "s2", type: "t1").ToEntity());
+                context.PersistedGrants.Add(CreateTestObject(sub: "sub4", clientId: "c2", sid: "s2", type: "t2").ToEntity());
+                context.PersistedGrants.Add(CreateTestObject(sub: "sub4", clientId: "c3", sid: "s3", type: "t3").ToEntity());
                 context.PersistedGrants.Add(CreateTestObject().ToEntity());
                 context.SaveChanges();
             }
@@ -131,54 +131,54 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
 
                 (await store.GetAllAsync(new PersistedGrantFilter
                 {
-                    SubjectId = "sub1"
+                    SubjectId = "sub4"
                 })).ToList().Count.Should().Be(9);
                 (await store.GetAllAsync(new PersistedGrantFilter
                 {
-                    SubjectId = "sub2"
+                    SubjectId = "sub5"
                 })).ToList().Count.Should().Be(0);
                 (await store.GetAllAsync(new PersistedGrantFilter
                 {
-                    SubjectId = "sub1",
+                    SubjectId = "sub4",
                     ClientId = "c1"
                 })).ToList().Count.Should().Be(4);
                 (await store.GetAllAsync(new PersistedGrantFilter
                 {
-                    SubjectId = "sub1",
+                    SubjectId = "sub4",
                     ClientId = "c2"
                 })).ToList().Count.Should().Be(4);
                 (await store.GetAllAsync(new PersistedGrantFilter
                 {
-                    SubjectId = "sub1",
+                    SubjectId = "sub4",
                     ClientId = "c3"
                 })).ToList().Count.Should().Be(1);
                 (await store.GetAllAsync(new PersistedGrantFilter
                 {
-                    SubjectId = "sub1",
+                    SubjectId = "sub4",
                     ClientId = "c4"
                 })).ToList().Count.Should().Be(0);
                 (await store.GetAllAsync(new PersistedGrantFilter
                 {
-                    SubjectId = "sub1",
+                    SubjectId = "sub4",
                     ClientId = "c1",
                     SessionId = "s1"
                 })).ToList().Count.Should().Be(2);
                 (await store.GetAllAsync(new PersistedGrantFilter
                 {
-                    SubjectId = "sub1",
+                    SubjectId = "sub4",
                     ClientId = "c3",
                     SessionId = "s1"
                 })).ToList().Count.Should().Be(0);
                 (await store.GetAllAsync(new PersistedGrantFilter
                 {
-                    SubjectId = "sub1",
+                    SubjectId = "sub4",
                     ClientId = "c1",
                     SessionId = "s1",
                     Type = "t1"
                 })).ToList().Count.Should().Be(1);
                 (await store.GetAllAsync(new PersistedGrantFilter
                 {
-                    SubjectId = "sub1",
+                    SubjectId = "sub4",
                     ClientId = "c1",
                     SessionId = "s1",
                     Type = "t3"

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/ResourceStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/ResourceStoreTests.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.EntityFramework.DbContexts;
 using IdentityServer4.EntityFramework.Mappers;
 using IdentityServer4.EntityFramework.Options;

--- a/src/EntityFramework.Storage/test/IntegrationTests/Stores/ResourceStoreTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/Stores/ResourceStoreTests.cs
@@ -21,7 +21,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Stores
     {
         public ScopeStoreTests(DatabaseProviderFixture<ConfigurationDbContext> fixture) : base(fixture)
         {
-            foreach (var options in ((TheoryData)TestDatabaseProviders).SelectMany(x => x.Select(y => (DbContextOptions<ConfigurationDbContext>)y)).ToList())
+            foreach (var options in TestDatabaseProviders.Select(x => x.Data).ToList())
             {
                 using (var context = new ConfigurationDbContext(options, StoreOptions))
                     context.Database.EnsureCreated();

--- a/src/EntityFramework.Storage/test/IntegrationTests/TokenCleanup/TokenCleanupTests.cs
+++ b/src/EntityFramework.Storage/test/IntegrationTests/TokenCleanup/TokenCleanupTests.cs
@@ -22,7 +22,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.TokenCleanup
 
         public TokenCleanupTests(DatabaseProviderFixture<PersistedGrantDbContext> fixture) : base(fixture)
         {
-            foreach (var options in ((TheoryData)TestDatabaseProviders).SelectMany(x => x.Select(y => (DbContextOptions<PersistedGrantDbContext>)y)).ToList())
+            foreach (var options in TestDatabaseProviders.Select(x => x.Data).ToList())
             {
                 using (var context = new PersistedGrantDbContext(options, StoreOptions))
                 {

--- a/src/EntityFramework.Storage/test/UnitTests/IdentityServer4.EntityFramework.UnitTests.csproj
+++ b/src/EntityFramework.Storage/test/UnitTests/IdentityServer4.EntityFramework.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
 
     <AssemblyOriginatorKeyFile>../../../../key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />

--- a/src/EntityFramework/build/build.csproj
+++ b/src/EntityFramework/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EntityFramework/host/Host.csproj
+++ b/src/EntityFramework/host/Host.csproj
@@ -1,20 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="3.1.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\src\IdentityServer4.EntityFramework.csproj" />
 
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
-    <PackageReference Include="System.Security.Principal.Windows" />
   </ItemGroup>
 
 </Project>

--- a/src/EntityFramework/host/Quickstart/Account/AccountController.cs
+++ b/src/EntityFramework/host/Quickstart/Account/AccountController.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4;
 using IdentityServer4.Events;
 using IdentityServer4.Extensions;

--- a/src/EntityFramework/host/Quickstart/Account/ExternalController.cs
+++ b/src/EntityFramework/host/Quickstart/Account/ExternalController.cs
@@ -1,4 +1,4 @@
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4;
 using IdentityServer4.Events;
 using IdentityServer4.Services;

--- a/src/EntityFramework/host/Quickstart/Diagnostics/DiagnosticsViewModel.cs
+++ b/src/EntityFramework/host/Quickstart/Diagnostics/DiagnosticsViewModel.cs
@@ -2,7 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using System.Buffers.Text;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using System.Collections.Generic;
 using System.Text;
@@ -19,7 +20,7 @@ namespace IdentityServerHost.Quickstart.UI
             if (result.Properties.Items.ContainsKey("client_list"))
             {
                 var encoded = result.Properties.Items["client_list"];
-                var bytes = Base64Url.Decode(encoded);
+                var bytes = Base64Url.DecodeFromChars(encoded);
                 var value = Encoding.UTF8.GetString(bytes);
 
                 Clients = JsonSerializer.Deserialize<string[]>(value);

--- a/src/EntityFramework/host/Quickstart/TestUsers.cs
+++ b/src/EntityFramework/host/Quickstart/TestUsers.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Test;
 using System.Collections.Generic;
 using System.Security.Claims;

--- a/src/EntityFramework/migrations/SqlServer/Configuration/Resources.cs
+++ b/src/EntityFramework/migrations/SqlServer/Configuration/Resources.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Models;
 using System.Collections.Generic;
 using static IdentityServer4.IdentityServerConstants;

--- a/src/EntityFramework/migrations/SqlServer/Program.cs
+++ b/src/EntityFramework/migrations/SqlServer/Program.cs
@@ -1,19 +1,28 @@
-﻿using Microsoft.AspNetCore;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 
 namespace SqlServer
 {
     class Program
     {
-        public static void Main(string[] args)
+        public static async Task Main(string[] args)
         {
             var host = BuildWebHost(args);
+            await host.StartAsync();
             SeedData.EnsureSeedData(host.Services);
+            await host.StopAsync();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
+        public static IHost BuildWebHost(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                        .UseStartup<Startup>()
+                        .UseKestrel();
+                })
                 .Build();
+      
     }
 }

--- a/src/EntityFramework/migrations/SqlServer/SqlServer.csproj
+++ b/src/EntityFramework/migrations/SqlServer/SqlServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EntityFramework/src/IdentityServer4.EntityFramework.csproj
+++ b/src/EntityFramework/src/IdentityServer4.EntityFramework.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>IdentityServer4.NET.EntityFramework</PackageId>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
 
     <Description>EntityFramework persistence layer for IdentityServer4</Description>
     <Authors>Sparkling Logic</Authors>

--- a/src/EntityFramework/test/IdentityServer4.EntityFramework.Tests/IdentityServer4.EntityFramework.Tests.csproj
+++ b/src/EntityFramework/test/IdentityServer4.EntityFramework.Tests/IdentityServer4.EntityFramework.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FluentAssertions" />
   

--- a/src/EntityFramework/test/IdentityServer4.EntityFramework.Tests/IntegrationTest.cs
+++ b/src/EntityFramework/test/IdentityServer4.EntityFramework.Tests/IntegrationTest.cs
@@ -17,9 +17,10 @@ namespace IdentityServer4.EntityFramework.IntegrationTests
     public class IntegrationTest<TClass, TDbContext, TStoreOption> : IClassFixture<DatabaseProviderFixture<TDbContext>>
         where TDbContext : DbContext
     {
-        public static readonly TheoryData<DbContextOptions<TDbContext>> TestDatabaseProviders;
         protected readonly TStoreOption StoreOptions = Activator.CreateInstance<TStoreOption>();
 
+        public static TheoryData<DbContextOptions<TDbContext>> TestDatabaseProviders => Providers;
+        private static readonly TheoryData<DbContextOptions<TDbContext>> Providers;
         static IntegrationTest()
         {
             var config = new ConfigurationBuilder()
@@ -30,7 +31,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests
             {
                 Console.WriteLine($"Running Local Tests for {typeof(TClass).Name}");
 
-                TestDatabaseProviders = new TheoryData<DbContextOptions<TDbContext>>
+                Providers = new TheoryData<DbContextOptions<TDbContext>>
                 {
                     DatabaseProviderBuilder.BuildInMemory<TDbContext>(typeof(TClass).Name),
                     DatabaseProviderBuilder.BuildSqlite<TDbContext>(typeof(TClass).Name),
@@ -39,7 +40,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests
             }
             else
             {
-                TestDatabaseProviders = new TheoryData<DbContextOptions<TDbContext>>
+                Providers = new TheoryData<DbContextOptions<TDbContext>>
                 {
                     DatabaseProviderBuilder.BuildInMemory<TDbContext>(typeof(TClass).Name),
                     DatabaseProviderBuilder.BuildSqlite<TDbContext>(typeof(TClass).Name)

--- a/src/EntityFramework/test/IdentityServer4.EntityFramework.Tests/IntegrationTest.cs
+++ b/src/EntityFramework/test/IdentityServer4.EntityFramework.Tests/IntegrationTest.cs
@@ -50,7 +50,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests
 
         protected IntegrationTest(DatabaseProviderFixture<TDbContext> fixture)
         {
-            fixture.Options = ((TheoryData) TestDatabaseProviders).SelectMany(x => x.Select(y => (DbContextOptions<TDbContext>)y)).ToList();
+            fixture.Options = TestDatabaseProviders.Select(x => x.Data).ToList();
             fixture.StoreOptions = StoreOptions;
         }
     }

--- a/src/EntityFramework/test/IdentityServer4.EntityFramework.Tests/Services/CorsPolicyServiceTests.cs
+++ b/src/EntityFramework/test/IdentityServer4.EntityFramework.Tests/Services/CorsPolicyServiceTests.cs
@@ -23,7 +23,7 @@ namespace IdentityServer4.EntityFramework.IntegrationTests.Services
     {
         public CorsPolicyServiceTests(DatabaseProviderFixture<ConfigurationDbContext> fixture) : base(fixture)
         {
-            foreach (var options in ((TheoryData) TestDatabaseProviders).SelectMany(x => x.Select(y => (DbContextOptions<ConfigurationDbContext>)y)).ToList())
+            foreach (var options in TestDatabaseProviders.Select(x => x.Data).ToList())
             {
                 using (var context = new ConfigurationDbContext(options, StoreOptions))
                     context.Database.EnsureCreated();

--- a/src/IdentityServer4/build/build.csproj
+++ b/src/IdentityServer4/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IdentityServer4/host/Configuration/Resources.cs
+++ b/src/IdentityServer4/host/Configuration/Resources.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Models;
 using System.Collections.Generic;
 using static IdentityServer4.IdentityServerConstants;

--- a/src/IdentityServer4/host/Host.csproj
+++ b/src/IdentityServer4/host/Host.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 
@@ -16,12 +16,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" />
     
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
 
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <!--<PackageReference Include="IdentityServer4.EntityFramework" />-->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="All" />
-    <PackageReference Include="System.Security.Principal.Windows" />
     
     <ProjectReference Include="..\src\IdentityServer4.csproj" />
   </ItemGroup>

--- a/src/IdentityServer4/host/Quickstart/Account/AccountController.cs
+++ b/src/IdentityServer4/host/Quickstart/Account/AccountController.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4;
 using IdentityServer4.Events;
 using IdentityServer4.Extensions;

--- a/src/IdentityServer4/host/Quickstart/Account/ExternalController.cs
+++ b/src/IdentityServer4/host/Quickstart/Account/ExternalController.cs
@@ -1,4 +1,4 @@
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4;
 using IdentityServer4.Events;
 using IdentityServer4.Services;

--- a/src/IdentityServer4/host/Quickstart/Diagnostics/DiagnosticsViewModel.cs
+++ b/src/IdentityServer4/host/Quickstart/Diagnostics/DiagnosticsViewModel.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using System.Buffers.Text;
 using Microsoft.AspNetCore.Authentication;
 using System.Collections.Generic;
 using System.Text;
@@ -19,7 +19,7 @@ namespace IdentityServerHost.Quickstart.UI
             if (result.Properties.Items.ContainsKey("client_list"))
             {
                 var encoded = result.Properties.Items["client_list"];
-                var bytes = Base64Url.Decode(encoded);
+                var bytes = Base64Url.DecodeFromChars(encoded);
                 var value = Encoding.UTF8.GetString(bytes);
 
                 Clients = JsonSerializer.Deserialize<string[]>(value);

--- a/src/IdentityServer4/host/Quickstart/TestUsers.cs
+++ b/src/IdentityServer4/host/Quickstart/TestUsers.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Test;
 using System.Collections.Generic;
 using System.Security.Claims;

--- a/src/IdentityServer4/host/Startup.cs
+++ b/src/IdentityServer4/host/Startup.cs
@@ -4,7 +4,7 @@
 
 using System;
 using IdentityServerHost.Configuration;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;

--- a/src/IdentityServer4/host/Startup.cs
+++ b/src/IdentityServer4/host/Startup.cs
@@ -137,14 +137,14 @@ namespace IdentityServerHost
             //builder.AddDeveloperSigningCredential();
 
             // use an RSA-based certificate with RS256
-            var rsaCert = new X509Certificate2("./keys/identityserver.test.rsa.p12", "changeit");
+            var rsaCert = X509CertificateLoader.LoadPkcs12FromFile("./keys/identityserver.test.rsa.p12", "changeit");
             builder.AddSigningCredential(rsaCert, "RS256");
 
             // ...and PS256
             builder.AddSigningCredential(rsaCert, "PS256");
 
             // or manually extract ECDSA key from certificate (directly using the certificate is not support by Microsoft right now)
-            var ecCert = new X509Certificate2("./keys/identityserver.test.ecdsa.p12", "changeit");
+            var ecCert = X509CertificateLoader.LoadPkcs12FromFile("./keys/identityserver.test.ecdsa.p12", "changeit");
             var key = new ECDsaSecurityKey(ecCert.GetECDsaPrivateKey())
             {
                 KeyId = CryptoRandom.CreateUniqueId(16, CryptoRandom.OutputFormat.Hex)
@@ -255,7 +255,7 @@ namespace IdentityServerHost
                     if(!string.IsNullOrWhiteSpace(headerValue))
                     {
                         byte[] bytes = Encoding.UTF8.GetBytes(Uri.UnescapeDataString(headerValue));
-                        clientCertificate = new X509Certificate2(bytes);
+                        clientCertificate = X509CertificateLoader.LoadCertificate(bytes);
                     }
 
                     return clientCertificate;

--- a/src/IdentityServer4/src/Configuration/CryptoHelper.cs
+++ b/src/IdentityServer4/src/Configuration/CryptoHelper.cs
@@ -1,6 +1,7 @@
-﻿using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.IdentityModel.Tokens;
 using System;
+using System.Buffers.Text;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -71,7 +72,7 @@ namespace IdentityServer4.Configuration
                 var leftPart = new byte[size];
                 Array.Copy(hash, leftPart, size);
 
-                return Base64Url.Encode(leftPart);
+                return Base64Url.EncodeToString(leftPart);
             }
         }
 

--- a/src/IdentityServer4/src/Configuration/DependencyInjection/Options/LoggingOptions.cs
+++ b/src/IdentityServer4/src/Configuration/DependencyInjection/Options/LoggingOptions.cs
@@ -3,7 +3,7 @@
 
 
 using System.Collections.Generic;
-using IdentityModel;
+using Duende.IdentityModel;
 
 namespace IdentityServer4.Configuration
 {

--- a/src/IdentityServer4/src/Constants.cs
+++ b/src/IdentityServer4/src/Constants.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Models;
 using System;
 using System.Collections.Generic;

--- a/src/IdentityServer4/src/Endpoints/AuthorizeEndpointBase.cs
+++ b/src/IdentityServer4/src/Endpoints/AuthorizeEndpointBase.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using System;
 using System.Collections.Specialized;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Configuration;
 using IdentityServer4.Endpoints.Results;
 using IdentityServer4.Events;

--- a/src/IdentityServer4/src/Endpoints/DeviceAuthorizationEndpoint.cs
+++ b/src/IdentityServer4/src/Endpoints/DeviceAuthorizationEndpoint.cs
@@ -4,7 +4,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Endpoints.Results;
 using IdentityServer4.Events;
 using IdentityServer4.Extensions;

--- a/src/IdentityServer4/src/Endpoints/Results/AuthorizeResult.cs
+++ b/src/IdentityServer4/src/Endpoints/Results/AuthorizeResult.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using IdentityServer4.Models;
 using IdentityServer4.Extensions;
 using IdentityServer4.Hosting;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using System;

--- a/src/IdentityServer4/src/Endpoints/Results/ProtectedResourceErrorResult.cs
+++ b/src/IdentityServer4/src/Endpoints/Results/ProtectedResourceErrorResult.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Primitives;
 using IdentityServer4.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Net.Http.Headers;
-using IdentityModel;
+using Duende.IdentityModel;
 
 namespace IdentityServer4.Endpoints.Results
 {

--- a/src/IdentityServer4/src/Endpoints/Results/TokenResult.cs
+++ b/src/IdentityServer4/src/Endpoints/Results/TokenResult.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.Hosting;
 using IdentityServer4.ResponseHandling;

--- a/src/IdentityServer4/src/Endpoints/TokenEndpoint.cs
+++ b/src/IdentityServer4/src/Endpoints/TokenEndpoint.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Endpoints.Results;
 using IdentityServer4.Events;
 using IdentityServer4.Extensions;

--- a/src/IdentityServer4/src/Endpoints/TokenRevocationEndpoint.cs
+++ b/src/IdentityServer4/src/Endpoints/TokenRevocationEndpoint.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Endpoints.Results;
 using IdentityServer4.Hosting;
 using IdentityServer4.Validation;

--- a/src/IdentityServer4/src/Endpoints/UserInfoEndpoint.cs
+++ b/src/IdentityServer4/src/Endpoints/UserInfoEndpoint.cs
@@ -8,7 +8,7 @@ using IdentityServer4.ResponseHandling;
 using Microsoft.Extensions.Logging;
 using IdentityServer4.Hosting;
 using IdentityServer4.Endpoints.Results;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Http;
 using System.Net;
 

--- a/src/IdentityServer4/src/Events/TokenIssuedSuccessEvent.cs
+++ b/src/IdentityServer4/src/Events/TokenIssuedSuccessEvent.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.ResponseHandling;
 using IdentityServer4.Validation;

--- a/src/IdentityServer4/src/Extensions/AuthenticationPropertiesExtensions.cs
+++ b/src/IdentityServer4/src/Extensions/AuthenticationPropertiesExtensions.cs
@@ -1,10 +1,10 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
 using Microsoft.AspNetCore.Authentication;
 using System;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -102,7 +102,7 @@ namespace IdentityServer4.Extensions
         {
             if (value.IsPresent())
             {
-                var bytes = Base64Url.Decode(value);
+                var bytes = Base64Url.DecodeFromChars(value);
                 value = Encoding.UTF8.GetString(bytes);
                 return ObjectSerializer.FromString<string[]>(value);
             }
@@ -116,7 +116,7 @@ namespace IdentityServer4.Extensions
             {
                 var value = ObjectSerializer.ToString(list);
                 var bytes = Encoding.UTF8.GetBytes(value);
-                value = Base64Url.Encode(bytes);
+                value = Base64Url.EncodeToString(bytes);
                 return value;
             }
 

--- a/src/IdentityServer4/src/Extensions/ClaimsExtensions.cs
+++ b/src/IdentityServer4/src/Extensions/ClaimsExtensions.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/IdentityServer4/src/Extensions/ClientExtensions.cs
+++ b/src/IdentityServer4/src/Extensions/ClientExtensions.cs
@@ -55,7 +55,7 @@ namespace IdentityServer4.Models
         {
             return secrets
                 .Where(s => s.Type == IdentityServerConstants.SecretTypes.X509CertificateBase64)
-                .Select(s => new X509Certificate2(Convert.FromBase64String(s.Value)))
+                .Select(s => X509CertificateLoader.LoadCertificate(Convert.FromBase64String(s.Value)))
                 .Where(c => c != null)
                 .ToList();
         }

--- a/src/IdentityServer4/src/Extensions/IdentityServerToolsExtensions.cs
+++ b/src/IdentityServer4/src/Extensions/IdentityServerToolsExtensions.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;

--- a/src/IdentityServer4/src/Extensions/PrincipalExtensions.cs
+++ b/src/IdentityServer4/src/Extensions/PrincipalExtensions.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/IdentityServer4/src/Extensions/TokenExtensions.cs
+++ b/src/IdentityServer4/src/Extensions/TokenExtensions.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Models;
 using Microsoft.Extensions.Logging;
 using System;

--- a/src/IdentityServer4/src/Extensions/ValidatedAuthorizeRequestExtensions.cs
+++ b/src/IdentityServer4/src/Extensions/ValidatedAuthorizeRequestExtensions.cs
@@ -2,9 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using System;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
@@ -125,7 +126,7 @@ namespace IdentityServer4.Validation
                 hash = sha.ComputeHash(bytes);
             }
 
-            return Base64Url.Encode(hash) + "." + salt;
+            return Base64Url.EncodeToString(hash) + "." + salt;
         }
     }
 }

--- a/src/IdentityServer4/src/Extensions/X509CertificateExtensions.cs
+++ b/src/IdentityServer4/src/Extensions/X509CertificateExtensions.cs
@@ -1,8 +1,8 @@
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
-using IdentityModel;
 
 namespace IdentityServer4.Extensions
 {
@@ -22,7 +22,7 @@ namespace IdentityServer4.Extensions
                             
             var values = new Dictionary<string, string>
             {
-                { "x5t#S256", Base64Url.Encode(hash) }
+                { "x5t#S256", Base64Url.EncodeToString(hash) }
             };
 
             return JsonSerializer.Serialize(values);

--- a/src/IdentityServer4/src/Hosting/IdentityServerAuthenticationService.cs
+++ b/src/IdentityServer4/src/Hosting/IdentityServerAuthenticationService.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 using IdentityServer4.Configuration.DependencyInjection;
 using IdentityServer4.Extensions;
 using System;
-using IdentityModel;
+using Duende.IdentityModel;
 using System.Linq;
 using IdentityServer4.Configuration;
 

--- a/src/IdentityServer4/src/Hosting/LocalApiAuthentication/LocalApiAuthenticationHandler.cs
+++ b/src/IdentityServer4/src/Hosting/LocalApiAuthentication/LocalApiAuthenticationHandler.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Validation;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;

--- a/src/IdentityServer4/src/IdentityServer4.csproj
+++ b/src/IdentityServer4/src/IdentityServer4.csproj
@@ -42,7 +42,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Storage\src\IdentityServer4.Storage.csproj" />
 	
-    <PackageReference Include="IdentityModel" />
+    <PackageReference Include="Duende.IdentityModel" />
 
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
 

--- a/src/IdentityServer4/src/IdentityServer4.csproj
+++ b/src/IdentityServer4/src/IdentityServer4.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <PackageId>IdentityServer4.NET</PackageId>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>OpenID Connect and OAuth 2.0 Framework for ASP.NET Core</Description>
     <Authors>Sparkling Logic</Authors>
     <AssemblyName>IdentityServer4</AssemblyName>

--- a/src/IdentityServer4/src/IdentityServerTools.cs
+++ b/src/IdentityServer4/src/IdentityServerTools.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 using IdentityServer4.Extensions;
 using System.Security.Claims;
 using IdentityServer4.Services;
-using IdentityModel;
+using Duende.IdentityModel;
 using System;
 using Microsoft.AspNetCore.Authentication;
 

--- a/src/IdentityServer4/src/IdentityServerUser.cs
+++ b/src/IdentityServer4/src/IdentityServerUser.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using System;
 using System.Collections.Generic;

--- a/src/IdentityServer4/src/Logging/Models/AuthorizeRequestValidationLog.cs
+++ b/src/IdentityServer4/src/Logging/Models/AuthorizeRequestValidationLog.cs
@@ -4,7 +4,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.Validation;
 

--- a/src/IdentityServer4/src/Logging/Models/DeviceAuthorizationRequestValidationLog.cs
+++ b/src/IdentityServer4/src/Logging/Models/DeviceAuthorizationRequestValidationLog.cs
@@ -3,7 +3,7 @@
 
 
 using System.Collections.Generic;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.Validation;
 

--- a/src/IdentityServer4/src/Logging/Models/EndSessionRequestValidationLog.cs
+++ b/src/IdentityServer4/src/Logging/Models/EndSessionRequestValidationLog.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using System.Collections.Generic;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.Validation;
 

--- a/src/IdentityServer4/src/Logging/Models/TokenRequestValidationLog.cs
+++ b/src/IdentityServer4/src/Logging/Models/TokenRequestValidationLog.cs
@@ -4,7 +4,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.Validation;
 

--- a/src/IdentityServer4/src/Models/IdentityResources.cs
+++ b/src/IdentityServer4/src/Models/IdentityResources.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using System.Linq;
 
 namespace IdentityServer4.Models

--- a/src/IdentityServer4/src/Models/Messages/ConsentRequest.cs
+++ b/src/IdentityServer4/src/Models/Messages/ConsentRequest.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using System.Buffers.Text;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -93,7 +94,7 @@ namespace IdentityServer4.Models
                     var bytes = Encoding.UTF8.GetBytes(value);
                     var hash = sha.ComputeHash(bytes);
 
-                    return Base64Url.Encode(hash);
+                    return Base64Url.EncodeToString(hash);
                 }
             }
         }

--- a/src/IdentityServer4/src/Models/Messages/LogoutRequest.cs
+++ b/src/IdentityServer4/src/Models/Messages/LogoutRequest.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.Validation;
 using System.Collections.Generic;

--- a/src/IdentityServer4/src/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
+++ b/src/IdentityServer4/src/ResponseHandling/Default/AuthorizeInteractionResponseGenerator.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;
 using IdentityServer4.Services;

--- a/src/IdentityServer4/src/ResponseHandling/Default/AuthorizeResponseGenerator.cs
+++ b/src/IdentityServer4/src/ResponseHandling/Default/AuthorizeResponseGenerator.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;
 using IdentityServer4.Services;

--- a/src/IdentityServer4/src/ResponseHandling/Default/DiscoveryResponseGenerator.cs
+++ b/src/IdentityServer4/src/ResponseHandling/Default/DiscoveryResponseGenerator.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Configuration;
 using IdentityServer4.Extensions;
 using IdentityServer4.Services;
@@ -11,6 +11,7 @@ using IdentityServer4.Validation;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
 using System;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
@@ -373,13 +374,13 @@ namespace IdentityServer4.ResponseHandling
                 if (key.Key is X509SecurityKey x509Key)
                 {
                     var cert64 = Convert.ToBase64String(x509Key.Certificate.RawData);
-                    var thumbprint = Base64Url.Encode(x509Key.Certificate.GetCertHash());
+                    var thumbprint = Base64Url.EncodeToString(x509Key.Certificate.GetCertHash());
 
                     if (x509Key.PublicKey is RSA rsa)
                     {
                         var parameters = rsa.ExportParameters(false);
-                        var exponent = Base64Url.Encode(parameters.Exponent);
-                        var modulus = Base64Url.Encode(parameters.Modulus);
+                        var exponent = Base64Url.EncodeToString(parameters.Exponent);
+                        var modulus = Base64Url.EncodeToString(parameters.Modulus);
 
                         var rsaJsonWebKey = new Models.JsonWebKey
                         {
@@ -397,8 +398,8 @@ namespace IdentityServer4.ResponseHandling
                     else if (x509Key.PublicKey is ECDsa ecdsa)
                     {
                         var parameters = ecdsa.ExportParameters(false);
-                        var x = Base64Url.Encode(parameters.Q.X);
-                        var y = Base64Url.Encode(parameters.Q.Y);
+                        var x = Base64Url.EncodeToString(parameters.Q.X);
+                        var y = Base64Url.EncodeToString(parameters.Q.Y);
 
                         var ecdsaJsonWebKey = new Models.JsonWebKey
                         {
@@ -422,8 +423,8 @@ namespace IdentityServer4.ResponseHandling
                 else if (key.Key is RsaSecurityKey rsaKey)
                 {
                     var parameters = rsaKey.Rsa?.ExportParameters(false) ?? rsaKey.Parameters;
-                    var exponent = Base64Url.Encode(parameters.Exponent);
-                    var modulus = Base64Url.Encode(parameters.Modulus);
+                    var exponent = Base64Url.EncodeToString(parameters.Exponent);
+                    var modulus = Base64Url.EncodeToString(parameters.Modulus);
 
                     var webKey = new Models.JsonWebKey
                     {
@@ -440,8 +441,8 @@ namespace IdentityServer4.ResponseHandling
                 else if (key.Key is ECDsaSecurityKey ecdsaKey)
                 {
                     var parameters = ecdsaKey.ECDsa.ExportParameters(false);
-                    var x = Base64Url.Encode(parameters.Q.X);
-                    var y = Base64Url.Encode(parameters.Q.Y);
+                    var x = Base64Url.EncodeToString(parameters.Q.X);
+                    var y = Base64Url.EncodeToString(parameters.Q.Y);
 
                     var ecdsaJsonWebKey = new Models.JsonWebKey
                     {

--- a/src/IdentityServer4/src/ResponseHandling/Default/IntrospectionResponseGenerator.cs
+++ b/src/IdentityServer4/src/ResponseHandling/Default/IntrospectionResponseGenerator.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Events;
 using IdentityServer4.Extensions;
 using IdentityServer4.Services;

--- a/src/IdentityServer4/src/ResponseHandling/Default/TokenResponseGenerator.cs
+++ b/src/IdentityServer4/src/ResponseHandling/Default/TokenResponseGenerator.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;
 using IdentityServer4.Services;

--- a/src/IdentityServer4/src/ResponseHandling/Default/UserInfoResponseGenerator.cs
+++ b/src/IdentityServer4/src/ResponseHandling/Default/UserInfoResponseGenerator.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;
 using IdentityServer4.Services;

--- a/src/IdentityServer4/src/ResponseHandling/Models/TokenErrorResponse.cs
+++ b/src/IdentityServer4/src/ResponseHandling/Models/TokenErrorResponse.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using System.Collections.Generic;
 
 namespace IdentityServer4.ResponseHandling

--- a/src/IdentityServer4/src/Services/Default/DefaultBackChannelLogoutService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultBackChannelLogoutService.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Models;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;

--- a/src/IdentityServer4/src/Services/Default/DefaultClaimsService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultClaimsService.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;
 using IdentityServer4.Validation;

--- a/src/IdentityServer4/src/Services/Default/DefaultHandleGenerationService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultHandleGenerationService.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using System.Threading.Tasks;
 
 namespace IdentityServer4.Services

--- a/src/IdentityServer4/src/Services/Default/DefaultJwtRequestUriHttpClient.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultJwtRequestUriHttpClient.cs
@@ -7,7 +7,7 @@ using IdentityServer4.Models;
 using Microsoft.Extensions.Logging;
 using System.Net.Http;
 using System.Threading.Tasks;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Configuration;
 
 namespace IdentityServer4.Services

--- a/src/IdentityServer4/src/Services/Default/DefaultRefreshTokenService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultRefreshTokenService.cs
@@ -9,7 +9,7 @@ using IdentityServer4.Stores;
 using Microsoft.Extensions.Logging;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Validation;
 
 namespace IdentityServer4.Services

--- a/src/IdentityServer4/src/Services/Default/DefaultTokenCreationService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultTokenCreationService.cs
@@ -2,14 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
 using IdentityServer4.Configuration;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
 using System;
+using System.Buffers.Text;
 using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Threading.Tasks;
@@ -101,7 +100,7 @@ namespace IdentityServer4.Services
                     Logger.LogWarning("Certificate {subjectName} has expired on {expiration}", cert.Subject, cert.NotAfter.ToString(CultureInfo.InvariantCulture));
                 }
 
-                header["x5t"] = Base64Url.Encode(cert.GetCertHash());
+                header["x5t"] = Base64Url.EncodeToString(cert.GetCertHash());
             }
 
             if (token.Type == TokenTypes.AccessToken)

--- a/src/IdentityServer4/src/Services/Default/DefaultTokenService.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultTokenService.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Configuration;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;

--- a/src/IdentityServer4/src/Services/Default/DefaultUserSession.cs
+++ b/src/IdentityServer4/src/Services/Default/DefaultUserSession.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Configuration;
 using IdentityServer4.Extensions;
 using Microsoft.AspNetCore.Http;

--- a/src/IdentityServer4/src/Services/Default/LogoutNotificationService.cs
+++ b/src/IdentityServer4/src/Services/Default/LogoutNotificationService.cs
@@ -1,7 +1,7 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;
 using IdentityServer4.Stores;

--- a/src/IdentityServer4/src/Stores/Default/DistributedCacheAuthorizationParametersMessageStore.cs
+++ b/src/IdentityServer4/src/Stores/Default/DistributedCacheAuthorizationParametersMessageStore.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Models;
 using IdentityServer4.Services;
 using Microsoft.Extensions.Caching.Distributed;

--- a/src/IdentityServer4/src/Stores/Default/ProtectedDataMessageStore.cs
+++ b/src/IdentityServer4/src/Stores/Default/ProtectedDataMessageStore.cs
@@ -5,9 +5,9 @@
 using IdentityServer4.Models;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.DataProtection;
-using IdentityModel;
 using System.Text;
 using System;
+using System.Buffers.Text;
 using Microsoft.Extensions.Logging;
 
 namespace IdentityServer4.Stores
@@ -50,7 +50,7 @@ namespace IdentityServer4.Stores
             {
                 try
                 {
-                    var bytes = Base64Url.Decode(value);
+                    var bytes = Base64Url.DecodeFromChars(value);
                     bytes = Protector.Unprotect(bytes);
                     var json = Encoding.UTF8.GetString(bytes);
                     result = ObjectSerializer.FromString<Message<TModel>>(json);
@@ -74,7 +74,7 @@ namespace IdentityServer4.Stores
                 var json = ObjectSerializer.ToString(message);
                 var bytes = Encoding.UTF8.GetBytes(json);
                 bytes = Protector.Protect(bytes);
-                value = Base64Url.Encode(bytes);
+                value = Base64Url.EncodeToString(bytes);
             }
             catch(Exception ex)
             {

--- a/src/IdentityServer4/src/Test/TestUser.cs
+++ b/src/IdentityServer4/src/Test/TestUser.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using System.Collections.Generic;
 using System.Security.Claims;
 

--- a/src/IdentityServer4/src/Test/TestUserResourceOwnerPasswordValidator.cs
+++ b/src/IdentityServer4/src/Test/TestUserResourceOwnerPasswordValidator.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Validation;
 using System.Threading.Tasks;
 using System;

--- a/src/IdentityServer4/src/Test/TestUserStore.cs
+++ b/src/IdentityServer4/src/Test/TestUserStore.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;

--- a/src/IdentityServer4/src/Validation/Default/AuthorizeRequestValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/AuthorizeRequestValidator.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Configuration;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;

--- a/src/IdentityServer4/src/Validation/Default/BasicAuthenticationSecretParser.cs
+++ b/src/IdentityServer4/src/Validation/Default/BasicAuthenticationSecretParser.cs
@@ -10,7 +10,7 @@ using System;
 using System.Text;
 using System.Threading.Tasks;
 using System.Linq;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Http;
 
 namespace IdentityServer4.Validation

--- a/src/IdentityServer4/src/Validation/Default/BearerTokenUsageValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/BearerTokenUsageValidator.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;

--- a/src/IdentityServer4/src/Validation/Default/DeviceAuthorizationRequestValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/DeviceAuthorizationRequestValidator.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Threading.Tasks;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Configuration;
 using IdentityServer4.Extensions;
 using IdentityServer4.Logging;

--- a/src/IdentityServer4/src/Validation/Default/DeviceCodeValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/DeviceCodeValidator.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;
 using IdentityServer4.Services;

--- a/src/IdentityServer4/src/Validation/Default/EndSessionRequestValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/EndSessionRequestValidator.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using Microsoft.Extensions.Logging;
 using System.Collections.Specialized;

--- a/src/IdentityServer4/src/Validation/Default/HashedSharedSecretValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/HashedSharedSecretValidator.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;
 using Microsoft.Extensions.Logging;

--- a/src/IdentityServer4/src/Validation/Default/JwtBearerClientAssertionSecretParser.cs
+++ b/src/IdentityServer4/src/Validation/Default/JwtBearerClientAssertionSecretParser.cs
@@ -6,7 +6,7 @@ using System;
 using System.Threading.Tasks;
 using System.Linq;
 using System.IdentityModel.Tokens.Jwt;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Configuration;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;

--- a/src/IdentityServer4/src/Validation/Default/JwtRequestValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/JwtRequestValidator.cs
@@ -8,7 +8,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Configuration;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;

--- a/src/IdentityServer4/src/Validation/Default/PlainTextSharedSecretValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/PlainTextSharedSecretValidator.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;
 using Microsoft.Extensions.Logging;

--- a/src/IdentityServer4/src/Validation/Default/PostBodySecretParser.cs
+++ b/src/IdentityServer4/src/Validation/Default/PostBodySecretParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -8,7 +8,7 @@ using IdentityServer4.Models;
 using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 using System.Linq;
-using IdentityModel;
+using Duende.IdentityModel;
 using Microsoft.AspNetCore.Http;
 
 namespace IdentityServer4.Validation

--- a/src/IdentityServer4/src/Validation/Default/TokenRequestValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/TokenRequestValidator.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Configuration;
 using IdentityServer4.Events;
 using IdentityServer4.Extensions;
@@ -11,13 +11,13 @@ using IdentityServer4.Services;
 using IdentityServer4.Stores;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using IdentityServer4.Logging.Models;
-using Microsoft.AspNetCore.Authentication;
 
 namespace IdentityServer4.Validation
 {
@@ -781,7 +781,7 @@ namespace IdentityServer4.Validation
 
             var codeVerifierBytes = Encoding.ASCII.GetBytes(codeVerifier);
             var hashedBytes = codeVerifierBytes.Sha256();
-            var transformedCodeVerifier = Base64Url.Encode(hashedBytes);
+            var transformedCodeVerifier = Base64Url.EncodeToString(hashedBytes);
 
             return TimeConstantComparer.IsEqual(transformedCodeVerifier.Sha256(), codeChallenge);
         }

--- a/src/IdentityServer4/src/Validation/Default/TokenRevocationRequestValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/TokenRevocationRequestValidator.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;
 using Microsoft.Extensions.Logging;

--- a/src/IdentityServer4/src/Validation/Default/TokenValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/TokenValidator.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;
 using IdentityServer4.Services;

--- a/src/IdentityServer4/src/Validation/Default/UserInfoRequestValidator.cs
+++ b/src/IdentityServer4/src/Validation/Default/UserInfoRequestValidator.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;
 using IdentityServer4.Services;

--- a/src/IdentityServer4/src/Validation/Models/GrantValidationResult.cs
+++ b/src/IdentityServer4/src/Validation/Models/GrantValidationResult.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;
 using System.Collections.Generic;

--- a/src/IdentityServer4/src/Validation/Models/ValidatedAuthorizeRequest.cs
+++ b/src/IdentityServer4/src/Validation/Models/ValidatedAuthorizeRequest.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/IdentityServer4/src/Validation/Models/ValidatedRequest.cs
+++ b/src/IdentityServer4/src/Validation/Models/ValidatedRequest.cs
@@ -7,7 +7,7 @@ using IdentityServer4.Configuration;
 using IdentityServer4.Models;
 using System.Collections.Specialized;
 using System.Security.Claims;
-using IdentityModel;
+using Duende.IdentityModel;
 using System.Linq;
 using System;
 

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ClientAssertionClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ClientAssertionClient.cs
@@ -2,6 +2,17 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
+using Duende.IdentityModel;
+using Duende.IdentityModel.Client;
+using FluentAssertions;
+using IdentityServer.IntegrationTests.Clients.Setup;
+using IdentityServer.IntegrationTests.Common;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.Tokens;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Buffers.Text;
 using System.Collections.Generic;
@@ -11,32 +22,39 @@ using System.Net.Http;
 using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
-using FluentAssertions;
-using Duende.IdentityModel;
-using Duende.IdentityModel.Client;
-using IdentityServer.IntegrationTests.Clients.Setup;
-using IdentityServer.IntegrationTests.Common;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.IdentityModel.Tokens;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace IdentityServer.IntegrationTests.Clients
 {
-    public class ClientAssertionClient
+    public class ClientAssertionClient: IAsyncLifetime
     {
         private const string TokenEndpoint = "https://idsvr4/connect/token";
         private const string ClientId = "certificate_base64_valid";
 
-        private readonly HttpClient _client;
+        private HttpClient _client;
+        private IHost _host;
 
-        public ClientAssertionClient()
+        public async ValueTask DisposeAsync()
         {
-            var builder = new WebHostBuilder()
-                .UseStartup<Startup>();
-            var server = new TestServer(builder);
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+
+        public async ValueTask InitializeAsync()
+        {
+            _host = new HostBuilder()
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                        .UseTestServer() // If using TestServer
+                        //.UseContentRoot(Directory.GetCurrentDirectory())
+                        .UseStartup<Startup>();
+                    //.UseKestrel();
+                })
+                .Build();
+            await _host.StartAsync();
+
+            var server = _host.GetTestServer();
 
             _client = server.CreateClient();
         }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ClientAssertionClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ClientAssertionClient.cs
@@ -3,6 +3,7 @@
 
 
 using System;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
@@ -11,8 +12,8 @@ using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
-using IdentityModel.Client;
+using Duende.IdentityModel;
+using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Clients.Setup;
 using IdentityServer.IntegrationTests.Common;
 using Microsoft.AspNetCore.Hosting;
@@ -254,7 +255,7 @@ namespace IdentityServer.IntegrationTests.Clients
         {
             var token = response.AccessToken.Split('.').Skip(1).Take(1).First();
             var dictionary = JsonConvert.DeserializeObject<Dictionary<string, object>>(
-                Encoding.UTF8.GetString(Base64Url.Decode(token)));
+                Encoding.UTF8.GetString(Base64Url.DecodeFromChars(token)));
 
             return dictionary;
         }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ClientCredentialsAndResourceOwnerClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ClientCredentialsAndResourceOwnerClient.cs
@@ -5,7 +5,7 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Clients.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ClientCredentialsAndResourceOwnerClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ClientCredentialsAndResourceOwnerClient.cs
@@ -9,21 +9,39 @@ using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Clients.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
 using Xunit;
 
 namespace IdentityServer.IntegrationTests.Clients
 {
-    public class ClientCredentialsandResourceOwnerClient
+    public class ClientCredentialsandResourceOwnerClient: IAsyncLifetime
     {
         private const string TokenEndpoint = "https://server/connect/token";
 
-        private readonly HttpClient _client;
+        private HttpClient _client;
+        private IHost _host;
 
-        public ClientCredentialsandResourceOwnerClient()
+        public async ValueTask DisposeAsync()
         {
-            var builder = new WebHostBuilder()
-                .UseStartup<Startup>();
-            var server = new TestServer(builder);
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+
+        public async ValueTask InitializeAsync()
+        {
+            _host = new HostBuilder()
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                        .UseTestServer() // If using TestServer
+                        //.UseContentRoot(Directory.GetCurrentDirectory())
+                        .UseStartup<Startup>();
+                    //.UseKestrel();
+                })
+                .Build();
+            await _host.StartAsync();
+
+            var server = _host.GetTestServer();
 
             _client = server.CreateClient();
         }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ClientCredentialsClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ClientCredentialsClient.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -9,8 +10,8 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
-using IdentityModel.Client;
+using Duende.IdentityModel;
+using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Clients.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
@@ -451,7 +452,7 @@ namespace IdentityServer.IntegrationTests.Clients
         {
             var token = response.AccessToken.Split('.').Skip(1).Take(1).First();
             var dictionary = JsonConvert.DeserializeObject<Dictionary<string, object>>(
-                Encoding.UTF8.GetString(Base64Url.Decode(token)));
+                Encoding.UTF8.GetString(Base64Url.DecodeFromChars(token)));
 
             return dictionary;
         }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ClientCredentialsClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ClientCredentialsClient.cs
@@ -15,23 +15,41 @@ using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Clients.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace IdentityServer.IntegrationTests.Clients
 {
-    public class ClientCredentialsClient
+    public class ClientCredentialsClient: IAsyncLifetime
     {
         private const string TokenEndpoint = "https://server/connect/token";
 
-        private readonly HttpClient _client;
+        private HttpClient _client;
+        private IHost _host;
 
-        public ClientCredentialsClient()
+        public async ValueTask DisposeAsync()
         {
-            var builder = new WebHostBuilder()
-                .UseStartup<Startup>();
-            var server = new TestServer(builder);
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+
+        public async ValueTask InitializeAsync()
+        {
+            _host = new HostBuilder()
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                        .UseTestServer() // If using TestServer
+                        //.UseContentRoot(Directory.GetCurrentDirectory())
+                        .UseStartup<Startup>();
+                    //.UseKestrel();
+                })
+                .Build();
+            await _host.StartAsync();
+
+            var server = _host.GetTestServer();
 
             _client = server.CreateClient();
         }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/CustomTokenRequestValidatorClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/CustomTokenRequestValidatorClient.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Clients.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/CustomTokenRequestValidatorClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/CustomTokenRequestValidatorClient.cs
@@ -3,7 +3,6 @@
 
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -11,25 +10,42 @@ using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Clients.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json;
 using Xunit;
 
 namespace IdentityServer.IntegrationTests.Clients
 {
-    public class CustomTokenRequestValidatorClient
+    public class CustomTokenRequestValidatorClient: IAsyncLifetime
     {
         private const string TokenEndpoint = "https://server/connect/token";
 
-        private readonly HttpClient _client;
+        private HttpClient _client;
+        private IHost _host;
 
-        public CustomTokenRequestValidatorClient()
+        public async ValueTask DisposeAsync()
+        {
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+
+        public async ValueTask InitializeAsync()
         {
             var val = new TestCustomTokenRequestValidator();
             Startup.CustomTokenRequestValidator = val;
+            _host = new HostBuilder()
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                        .UseTestServer() // If using TestServer
+                        //.UseContentRoot(Directory.GetCurrentDirectory())
+                        .UseStartup<Startup>();
+                    //.UseKestrel();
+                })
+                .Build();
+            await _host.StartAsync();
 
-            var builder = new WebHostBuilder()
-                .UseStartup<Startup>();
-            var server = new TestServer(builder);
+            var server = _host.GetTestServer();
 
             _client = server.CreateClient();
         }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/CustomTokenResponseClients.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/CustomTokenResponseClients.cs
@@ -3,14 +3,14 @@
 
 
 using System;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Clients.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
@@ -288,7 +288,7 @@ namespace IdentityServer.IntegrationTests.Clients
         {
             var token = response.AccessToken.Split('.').Skip(1).Take(1).First();
             var dictionary = JsonConvert.DeserializeObject<Dictionary<string, object>>(
-                Encoding.UTF8.GetString(Base64Url.Decode(token)));
+                Encoding.UTF8.GetString(Base64Url.DecodeFromChars(token)));
 
             return dictionary;
         }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/CustomTokenResponseClients.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/CustomTokenResponseClients.cs
@@ -14,23 +14,41 @@ using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Clients.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace IdentityServer.IntegrationTests.Clients
 {
-    public class CustomTokenResponseClients
+    public class CustomTokenResponseClients: IAsyncLifetime
     {
         private const string TokenEndpoint = "https://server/connect/token";
 
-        private readonly HttpClient _client;
+        private HttpClient _client;
+        private IHost _host;
 
-        public CustomTokenResponseClients()
+        public async ValueTask DisposeAsync()
         {
-            var builder = new WebHostBuilder()
-                .UseStartup<StartupWithCustomTokenResponses>();
-            var server = new TestServer(builder);
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+
+        public async ValueTask InitializeAsync()
+        {
+            _host = new HostBuilder()
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                        .UseTestServer() // If using TestServer
+                        //.UseContentRoot(Directory.GetCurrentDirectory())
+                        .UseStartup<StartupWithCustomTokenResponses>();
+                    //.UseKestrel();
+                })
+                .Build();
+            await _host.StartAsync();
+
+            var server = _host.GetTestServer();
 
             _client = server.CreateClient();
         }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/DiscoveryClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/DiscoveryClient.cs
@@ -3,7 +3,7 @@
 
 
 using FluentAssertions;
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using System.Linq;

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/DiscoveryClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/DiscoveryClient.cs
@@ -10,21 +10,39 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using IdentityServer.IntegrationTests.Clients.Setup;
+using Microsoft.Extensions.Hosting;
 using Xunit;
 
 namespace IdentityServer.IntegrationTests.Clients
 {
-    public class DiscoveryClientTests
+    public class DiscoveryClientTests: IAsyncLifetime
     {
         private const string DiscoveryEndpoint = "https://server/.well-known/openid-configuration";
 
-        private readonly HttpClient _client;
+        private HttpClient _client;
+        private IHost _host;
 
-        public DiscoveryClientTests()
+        public async ValueTask DisposeAsync()
         {
-            var builder = new WebHostBuilder()
-                .UseStartup<Startup>();
-            var server = new TestServer(builder);
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+
+        public async ValueTask InitializeAsync()
+        {
+            _host = new HostBuilder()
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                        .UseTestServer() // If using TestServer
+                        //.UseContentRoot(Directory.GetCurrentDirectory())
+                        .UseStartup<Startup>();
+                    //.UseKestrel();
+                })
+                .Build();
+            await _host.StartAsync();
+
+            var server = _host.GetTestServer();
 
             _client = server.CreateClient();
         }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ExtensionGrantClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ExtensionGrantClient.cs
@@ -17,23 +17,41 @@ using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Clients.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace IdentityServer.IntegrationTests.Clients
 {
-    public class ExtensionGrantClient
+    public class ExtensionGrantClient: IAsyncLifetime
     {
         private const string TokenEndpoint = "https://server/connect/token";
 
-        private readonly HttpClient _client;
+        private HttpClient _client;
+        private IHost _host;
 
-        public ExtensionGrantClient()
+        public async ValueTask DisposeAsync()
         {
-            var builder = new WebHostBuilder()
-                .UseStartup<Startup>();
-            var server = new TestServer(builder);
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+
+        public async ValueTask InitializeAsync()
+        {
+            _host = new HostBuilder()
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                        .UseTestServer() // If using TestServer
+                        //.UseContentRoot(Directory.GetCurrentDirectory())
+                        .UseStartup<Startup>();
+                    //.UseKestrel();
+                })
+                .Build();
+            await _host.StartAsync();
+
+            var server = _host.GetTestServer();
 
             _client = server.CreateClient();
         }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ExtensionGrantClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ExtensionGrantClient.cs
@@ -3,6 +3,7 @@
 
 
 using System;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
@@ -11,8 +12,8 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
-using IdentityModel.Client;
+using Duende.IdentityModel;
+using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Clients.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
@@ -589,7 +590,7 @@ namespace IdentityServer.IntegrationTests.Clients
         {
             var token = response.AccessToken.Split('.').Skip(1).Take(1).First();
             var dictionary = JsonConvert.DeserializeObject<Dictionary<string, object>>(
-                Encoding.UTF8.GetString(Base64Url.Decode(token)));
+                Encoding.UTF8.GetString(Base64Url.DecodeFromChars(token)));
 
             return dictionary;
         }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/RefreshTokenClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/RefreshTokenClient.cs
@@ -5,7 +5,7 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Clients.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/RefreshTokenClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/RefreshTokenClient.cs
@@ -9,22 +9,40 @@ using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Clients.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
 using Xunit;
 
 namespace IdentityServer.IntegrationTests.Clients
 {
-    public class RefreshTokenClient
+    public class RefreshTokenClient: IAsyncLifetime
     {
         private const string TokenEndpoint = "https://server/connect/token";
         private const string RevocationEndpoint = "https://server/connect/revocation";
 
-        private readonly HttpClient _client;
+        private HttpClient _client;
+        private IHost _host;
 
-        public RefreshTokenClient()
+        public async ValueTask DisposeAsync()
         {
-            var builder = new WebHostBuilder()
-                .UseStartup<Startup>();
-            var server = new TestServer(builder);
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+
+        public async ValueTask InitializeAsync()
+        {
+            _host = new HostBuilder()
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                        .UseTestServer() // If using TestServer
+                        //.UseContentRoot(Directory.GetCurrentDirectory())
+                        .UseStartup<Startup>();
+                    //.UseKestrel();
+                })
+                .Build();
+            await _host.StartAsync();
+
+            var server = _host.GetTestServer();
 
             _client = server.CreateClient();
         }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ResourceOwnerClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ResourceOwnerClient.cs
@@ -14,23 +14,41 @@ using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Clients.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace IdentityServer.IntegrationTests.Clients
 {
-    public class ResourceOwnerClient
+    public class ResourceOwnerClient: IAsyncLifetime
     {
         private const string TokenEndpoint = "https://server/connect/token";
 
-        private readonly HttpClient _client;
+        private HttpClient _client;
+        private IHost _host;
 
-        public ResourceOwnerClient()
+        public async ValueTask DisposeAsync()
         {
-            var builder = new WebHostBuilder()
-                .UseStartup<Startup>();
-            var server = new TestServer(builder);
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+
+        public async ValueTask InitializeAsync()
+        {
+            _host = new HostBuilder()
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                        .UseTestServer() // If using TestServer
+                        //.UseContentRoot(Directory.GetCurrentDirectory())
+                        .UseStartup<Startup>();
+                    //.UseKestrel();
+                })
+                .Build();
+            await _host.StartAsync();
+
+            var server = _host.GetTestServer();
 
             _client = server.CreateClient();
         }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ResourceOwnerClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/ResourceOwnerClient.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -9,8 +10,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Clients.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
@@ -269,11 +269,11 @@ namespace IdentityServer.IntegrationTests.Clients
         }
 
 
-        private static Dictionary<string, object> GetPayload(IdentityModel.Client.TokenResponse response)
+        private static Dictionary<string, object> GetPayload(Duende.IdentityModel.Client.TokenResponse response)
         {
             var token = response.AccessToken.Split('.').Skip(1).Take(1).First();
             var dictionary = JsonConvert.DeserializeObject<Dictionary<string, object>>(
-                Encoding.UTF8.GetString(Base64Url.Decode(token)));
+                Encoding.UTF8.GetString(Base64Url.DecodeFromChars(token)));
 
             return dictionary;
         }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/RevocationClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/RevocationClient.cs
@@ -5,7 +5,7 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Clients.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/RevocationClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/RevocationClient.cs
@@ -9,23 +9,41 @@ using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Clients.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
 using Xunit;
 
 namespace IdentityServer.IntegrationTests.Clients
 {
-    public class RevocationClient
+    public class RevocationClient: IAsyncLifetime
     {
         private const string TokenEndpoint = "https://server/connect/token";
         private const string RevocationEndpoint = "https://server/connect/revocation";
         private const string IntrospectionEndpoint = "https://server/connect/introspect";
 
-        private readonly HttpClient _client;
+        private HttpClient _client;
+        private IHost _host;
 
-        public RevocationClient()
+        public async ValueTask DisposeAsync()
         {
-            var builder = new WebHostBuilder()
-                .UseStartup<Startup>();
-            var server = new TestServer(builder);
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+
+        public async ValueTask InitializeAsync()
+        {
+            _host = new HostBuilder()
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                        .UseTestServer() // If using TestServer
+                        //.UseContentRoot(Directory.GetCurrentDirectory())
+                        .UseStartup<Startup>();
+                    //.UseKestrel();
+                })
+                .Build();
+            await _host.StartAsync();
+
+            var server = _host.GetTestServer();
 
             _client = server.CreateClient();
         }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/Setup/Users.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/Setup/Users.cs
@@ -1,10 +1,10 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using System.Collections.Generic;
 using System.Security.Claims;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4;
 using IdentityServer4.Test;
 

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/UserInfoClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/UserInfoClient.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -9,8 +10,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Clients.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
@@ -204,7 +204,7 @@ namespace IdentityServer.IntegrationTests.Clients
         {
             var token = response.AccessToken.Split('.').Skip(1).Take(1).First();
             var dictionary = JsonConvert.DeserializeObject<Dictionary<string, object>>(
-                Encoding.UTF8.GetString(Base64Url.Decode(token)));
+                Encoding.UTF8.GetString(Base64Url.DecodeFromChars(token)));
 
             return dictionary;
         }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/UserInfoClient.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Clients/UserInfoClient.cs
@@ -14,24 +14,42 @@ using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Clients.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace IdentityServer.IntegrationTests.Clients
 {
-    public class UserInfoEndpointClient
+    public class UserInfoEndpointClient: IAsyncLifetime
     {
         private const string TokenEndpoint = "https://server/connect/token";
         private const string UserInfoEndpoint = "https://server/connect/userinfo";
 
-        private readonly HttpClient _client;
+        private HttpClient _client;
+        private IHost _host;
 
-        public UserInfoEndpointClient()
+        public async ValueTask DisposeAsync()
         {
-            var builder = new WebHostBuilder()
-                .UseStartup<Startup>();
-            var server = new TestServer(builder);
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+
+        public async ValueTask InitializeAsync()
+        {
+            _host = new HostBuilder()
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                        .UseTestServer() // If using TestServer
+                        //.UseContentRoot(Directory.GetCurrentDirectory())
+                        .UseStartup<Startup>();
+                    //.UseKestrel();
+                })
+                .Build();
+            await _host.StartAsync();
+
+            var server = _host.GetTestServer();
 
             _client = server.CreateClient();
         }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
@@ -11,7 +11,7 @@ using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using IdentityServer4;
 using IdentityServer4.Configuration;
 using IdentityServer4.Extensions;

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Common/IdentityServerPipeline.cs
@@ -24,12 +24,13 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
 namespace IdentityServer.IntegrationTests.Common
 {
-    public class IdentityServerPipeline
+    public class IdentityServerPipeline: IAsyncDisposable
     {
         public const string BaseUrl = "https://server";
         public const string LoginPage = BaseUrl + "/account/login";
@@ -74,36 +75,57 @@ namespace IdentityServer.IntegrationTests.Common
         public event Action<IApplicationBuilder> OnPostConfigure = app => { };
 
         public Func<HttpContext, Task<bool>> OnFederatedSignout;
+        private IHost _host;
 
-        public void Initialize(string basePath = null, bool enableLogging = false)
+        public async ValueTask InitializeAsync(string basePath = null, bool enableLogging = false)
         {
-            var builder = new WebHostBuilder();
-            builder.ConfigureServices(ConfigureServices);
-            builder.Configure(app=>
+            if (_host != null)
             {
-                if (basePath != null)
-                {
-                    app.Map(basePath, map =>
-                    {
-                        ConfigureApp(map);
-                    });
-                }
-                else
-                {
-                    ConfigureApp(app);
-                }
-            });
-
-            if (enableLogging)
-            {
-                builder.ConfigureLogging((ctx, b) => b.AddConsole());
+                await DisposeAsync();
             }
+            _host = new HostBuilder()
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                        .UseTestServer() // If using TestServer
+                        .ConfigureServices(ConfigureServices)
+                        .Configure(app =>
+                        {
+                            if (basePath != null)
+                            {
+                                app.Map(basePath, map =>
+                                {
+                                    ConfigureApp(map);
+                                });
+                            }
+                            else
+                            {
+                                ConfigureApp(app);
+                            }
+                        });
+                    if (enableLogging)
+                    {
+                        webHostBuilder.ConfigureLogging((ctx, b) => b.AddConsole());
+                    }
+                    //.UseContentRoot(Directory.GetCurrentDirectory())
+                    //.UseStartup<Startup>();
+                    //.UseKestrel();
+                })
+                .Build();
+            await _host.StartAsync();
 
-            Server = new TestServer(builder);
+            Server = _host.GetTestServer();
             Handler = Server.CreateHandler();
-            
+
             BrowserClient = new BrowserClient(new BrowserHandler(Handler));
             BackChannelClient = new HttpClient(Handler);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Handler?.Dispose();
+            await _host.StopAsync();
+            _host.Dispose();
         }
 
         public void ConfigureServices(IServiceCollection services)

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Common/TestCert.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Common/TestCert.cs
@@ -12,7 +12,7 @@ namespace IdentityServer.IntegrationTests.Common
         public static X509Certificate2 Load()
         {
             var cert = Path.Combine(System.AppContext.BaseDirectory, "identityserver_testing.pfx");
-            return new X509Certificate2(cert, "password");
+            return X509CertificateLoader.LoadPkcs12FromFile(cert, "password");
         }
     }
 }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Conformance/Basic/ClientAuthenticationTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Conformance/Basic/ClientAuthenticationTests.cs
@@ -8,7 +8,7 @@ using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Common;
 using IdentityServer4.Models;
 using IdentityServer4.Test;

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Conformance/Basic/ClientAuthenticationTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Conformance/Basic/ClientAuthenticationTests.cs
@@ -16,13 +16,18 @@ using Xunit;
 
 namespace IdentityServer.IntegrationTests.Conformance.Basic
 {
-    public class ClientAuthenticationTests 
+    public class ClientAuthenticationTests: IAsyncLifetime 
     {
         private const string Category = "Conformance.Basic.ClientAuthenticationTests";
 
         private IdentityServerPipeline _pipeline = new IdentityServerPipeline();
 
-        public ClientAuthenticationTests()
+        public async ValueTask DisposeAsync()
+        {
+            await _pipeline.DisposeAsync();
+        }
+
+        public async ValueTask InitializeAsync()
         {
             _pipeline.IdentityScopes.Add(new IdentityResources.OpenId());
             _pipeline.Clients.Add(new Client
@@ -51,14 +56,14 @@ namespace IdentityServer.IntegrationTests.Conformance.Basic
                 SubjectId = "bob",
                 Username = "bob",
                 Claims = new Claim[]
-                   {
-                        new Claim("name", "Bob Loblaw"),
-                        new Claim("email", "bob@loblaw.com"),
-                        new Claim("role", "Attorney")
-                   }
+                {
+                    new Claim("name", "Bob Loblaw"),
+                    new Claim("email", "bob@loblaw.com"),
+                    new Claim("role", "Attorney")
+                }
             });
 
-            _pipeline.Initialize();
+            await _pipeline.InitializeAsync();
         }
 
         [Fact]

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Conformance/Basic/CodeFlowTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Conformance/Basic/CodeFlowTests.cs
@@ -10,7 +10,7 @@ using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Common;
 using IdentityServer4.Configuration;
 using IdentityServer4.Models;

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Conformance/Basic/CodeFlowTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Conformance/Basic/CodeFlowTests.cs
@@ -19,13 +19,17 @@ using Xunit;
 
 namespace IdentityServer.IntegrationTests.Conformance.Basic
 {
-    public class CodeFlowTests 
+    public class CodeFlowTests: IAsyncLifetime 
     {
         private const string Category = "Conformance.Basic.CodeFlowTests";
 
         private IdentityServerPipeline _pipeline = new IdentityServerPipeline();
+        public async ValueTask DisposeAsync()
+        {
+            await _pipeline.DisposeAsync();
+        }
 
-        public CodeFlowTests()
+        public async ValueTask InitializeAsync()
         {
             _pipeline.IdentityScopes.Add(new IdentityResources.OpenId());
             _pipeline.Clients.Add(new Client
@@ -61,7 +65,7 @@ namespace IdentityServer.IntegrationTests.Conformance.Basic
                    }
             });
 
-            _pipeline.Initialize();
+            await _pipeline.InitializeAsync();
         }
 
         [Fact]

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Conformance/Basic/RedirectUriTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Conformance/Basic/RedirectUriTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -15,15 +15,19 @@ using Xunit;
 
 namespace IdentityServer.IntegrationTests.Conformance.Basic
 {
-    public class RedirectUriTests
+    public class RedirectUriTests: IAsyncLifetime
     {
         private const string Category = "Conformance.Basic.RedirectUriTests";
 
         private IdentityServerPipeline _mockPipeline = new IdentityServerPipeline();
-
-        public RedirectUriTests()
+        public async ValueTask DisposeAsync()
         {
-            _mockPipeline.Initialize();
+            await _mockPipeline.DisposeAsync();
+        }
+
+        public async ValueTask InitializeAsync()
+        {
+            await _mockPipeline.InitializeAsync();
 
             _mockPipeline.Clients.Add(new Client
             {

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Conformance/Basic/ResponseTypeResponseModeTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Conformance/Basic/ResponseTypeResponseModeTests.cs
@@ -16,15 +16,19 @@ using Xunit.Sdk;
 
 namespace IdentityServer.IntegrationTests.Conformance.Basic
 {
-    public class ResponseTypeResponseModeTests
+    public class ResponseTypeResponseModeTests: IAsyncLifetime
     {
         private const string Category = "Conformance.Basic.ResponseTypeResponseModeTests";
 
         private IdentityServerPipeline _mockPipeline = new IdentityServerPipeline();
-
-        public ResponseTypeResponseModeTests()
+        public async ValueTask DisposeAsync()
         {
-            _mockPipeline.Initialize();
+            await _mockPipeline.DisposeAsync();
+        }
+
+        public async ValueTask InitializeAsync()
+        {
+            await _mockPipeline.InitializeAsync();
             _mockPipeline.BrowserClient.AllowAutoRedirect = false;
             _mockPipeline.Clients.Add(new Client
             {

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Conformance/Basic/ResponseTypeResponseModeTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Conformance/Basic/ResponseTypeResponseModeTests.cs
@@ -83,7 +83,7 @@ namespace IdentityServer.IntegrationTests.Conformance.Basic
             var response = await _mockPipeline.BrowserClient.GetAsync(url);
             response.StatusCode.Should().Be(HttpStatusCode.Found);
 
-            var authorization = new IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+            var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
             authorization.IsError.Should().BeFalse();
             authorization.Code.Should().NotBeNull();
             authorization.State.Should().Be(state);

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Conformance/Pkce/PkceTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Conformance/Pkce/PkceTests.cs
@@ -19,7 +19,7 @@ using Xunit;
 
 namespace IdentityServer.IntegrationTests.Conformance.Pkce
 {
-    public class PkceTests
+    public class PkceTests: IAsyncLifetime
     {
         private const string Category = "PKCE";
 
@@ -39,7 +39,12 @@ namespace IdentityServer.IntegrationTests.Conformance.Pkce
         private string client_secret = "secret";
         private string response_type = "code";
 
-        public PkceTests()
+        public async ValueTask DisposeAsync()
+        {
+            await _pipeline.DisposeAsync();
+        }
+
+        public async ValueTask InitializeAsync()
         {
             _pipeline.Users.Add(new TestUser
             {
@@ -159,7 +164,7 @@ namespace IdentityServer.IntegrationTests.Conformance.Pkce
                 }
             });
 
-            _pipeline.Initialize();
+            await _pipeline.InitializeAsync();
         }
 
         [Theory]

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Conformance/Pkce/PkceTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Conformance/Pkce/PkceTests.cs
@@ -3,13 +3,14 @@
 
 
 using System;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
-using IdentityModel.Client;
+using Duende.IdentityModel;
+using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Common;
 using IdentityServer4;
 using IdentityServer4.Models;
@@ -534,7 +535,7 @@ namespace IdentityServer.IntegrationTests.Conformance.Pkce
         {
             var codeVerifierBytes = Encoding.ASCII.GetBytes(codeVerifier);
             var hashedBytes = codeVerifierBytes.Sha256();
-            var transformedCodeVerifier = Base64Url.Encode(hashedBytes);
+            var transformedCodeVerifier = Base64Url.EncodeToString(hashedBytes);
 
             return transformedCodeVerifier;
         }

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -9,7 +9,7 @@ using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.IntegrationTests.Common;
 using IdentityServer4;
 using IdentityServer4.Models;
@@ -233,7 +233,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
             response.StatusCode.Should().Be(HttpStatusCode.Redirect);
             response.Headers.Location.ToString().Should().StartWith("https://client1/callback");
 
-            var authorization = new IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+            var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
             authorization.IsError.Should().BeFalse();
             authorization.IdentityToken.Should().NotBeNull();
             authorization.State.Should().Be("123_state");
@@ -259,7 +259,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
             response.StatusCode.Should().Be(HttpStatusCode.Redirect);
             response.Headers.Location.ToString().Should().StartWith("https://client1/callback");
 
-            var authorization = new IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+            var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
             authorization.IsError.Should().BeFalse();
             authorization.IdentityToken.Should().NotBeNull();
             authorization.State.Should().Be("123_state");
@@ -302,7 +302,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
             response.StatusCode.Should().Be(HttpStatusCode.Redirect);
             response.Headers.Location.ToString().Should().StartWith("https://client2/callback");
 
-            var authorization = new IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+            var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
             authorization.IsError.Should().BeFalse();
             authorization.IdentityToken.Should().NotBeNull();
             authorization.State.Should().Be("123_state");

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Authorize/AuthorizeTests.cs
@@ -21,7 +21,7 @@ using Xunit;
 
 namespace IdentityServer.IntegrationTests.Endpoints.Authorize
 {
-    public class AuthorizeTests
+    public class AuthorizeTests: IAsyncLifetime
     {
         private const string Category = "Authorize endpoint";
 
@@ -29,7 +29,12 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
 
         private Client _client1;
 
-        public AuthorizeTests()
+        public async ValueTask DisposeAsync()
+        {
+            await _mockPipeline.DisposeAsync();
+        }
+
+        public async ValueTask InitializeAsync()
         {
             _mockPipeline.Clients.AddRange(new Client[] {
                 _client1 = new Client
@@ -112,7 +117,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
                 }
             });
 
-            _mockPipeline.Initialize();
+            await _mockPipeline.InitializeAsync();
         }
 
         [Fact]
@@ -182,7 +187,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
                 {
                     services.AddTransient(typeof(IAuthorizationParametersMessageStore), storeType);
                 };
-                _mockPipeline.Initialize();
+                await _mockPipeline.InitializeAsync();
             }
 
             var url = _mockPipeline.CreateAuthorizeUrl(
@@ -278,7 +283,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
                 {
                     services.AddTransient(typeof(IAuthorizationParametersMessageStore), storeType);
                 };
-                _mockPipeline.Initialize();
+                await _mockPipeline.InitializeAsync();
             }
 
             _mockPipeline.Subject = new IdentityServerUser("bob").CreatePrincipal();

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Authorize/ConsentTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Authorize/ConsentTests.cs
@@ -198,7 +198,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
             response.StatusCode.Should().Be(HttpStatusCode.Redirect);
             response.Headers.Location.ToString().Should().StartWith("https://client2/callback");
 
-            var authorization = new IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+            var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
             authorization.IsError.Should().BeFalse();
             authorization.IdentityToken.Should().NotBeNull();
             authorization.State.Should().Be("123_state");
@@ -266,7 +266,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
             response.StatusCode.Should().Be(HttpStatusCode.Redirect);
             response.Headers.Location.ToString().Should().StartWith("https://client2/callback");
 
-            var authorization = new IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+            var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
             authorization.IsError.Should().BeTrue();
             authorization.Error.Should().Be("access_denied");
             authorization.State.Should().Be("123_state");

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Authorize/ConsentTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Authorize/ConsentTests.cs
@@ -18,13 +18,18 @@ using Xunit;
 
 namespace IdentityServer.IntegrationTests.Endpoints.Authorize
 {
-    public class ConsentTests
+    public class ConsentTests: IAsyncLifetime
     {
         private const string Category = "Authorize and consent tests";
 
         private IdentityServerPipeline _mockPipeline = new IdentityServerPipeline();
 
-        public ConsentTests()
+        public async ValueTask DisposeAsync()
+        {
+            await _mockPipeline.DisposeAsync();
+        }
+
+        public async ValueTask InitializeAsync()
         {
             _mockPipeline.Clients.AddRange(new Client[] {
                 new Client
@@ -94,7 +99,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
                 }
             });
 
-            _mockPipeline.Initialize();
+            await _mockPipeline.InitializeAsync();
         }
 
         [Fact]
@@ -129,7 +134,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
                 {
                     services.AddTransient(typeof(IAuthorizationParametersMessageStore), storeType);
                 };
-                _mockPipeline.Initialize();
+                await _mockPipeline.InitializeAsync();
             }
 
             await _mockPipeline.LoginAsync("bob");
@@ -175,7 +180,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
                 {
                     services.AddTransient(typeof(IAuthorizationParametersMessageStore), storeType);
                 };
-                _mockPipeline.Initialize();
+                await _mockPipeline.InitializeAsync();
             }
 
             await _mockPipeline.LoginAsync("bob");

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Authorize/JwtRequestAuthorizeTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Authorize/JwtRequestAuthorizeTests.cs
@@ -11,7 +11,7 @@ using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.IntegrationTests.Common;
 using IdentityServer4;
 using IdentityServer4.Configuration;

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Authorize/JwtRequestAuthorizeTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Authorize/JwtRequestAuthorizeTests.cs
@@ -24,17 +24,22 @@ using Xunit;
 
 namespace IdentityServer.IntegrationTests.Endpoints.Authorize
 {
-    public class JwtRequestAuthorizeTests
+    public class JwtRequestAuthorizeTests: IAsyncLifetime
     {
         private const string Category = "Authorize endpoint with JWT requests";
 
         private readonly IdentityServerPipeline _mockPipeline = new IdentityServerPipeline();
-        private readonly Client _client;
+        private Client _client;
 
         private readonly string _symmetricJwk = @"{ ""kty"": ""oct"", ""use"": ""sig"", ""kid"": ""1"", ""k"": ""nYA-IFt8xTsdBHe9hunvizcp3Dt7f6qGqudq18kZHNtvqEGjJ9Ud-9x3kbQ-LYfLHS3xM2MpFQFg1JzT_0U_F8DI40oby4TvBDGszP664UgA8_5GjB7Flnrlsap1NlitvNpgQX3lpyTvC2zVuQ-UVsXbBDAaSBUSlnw7SE4LM8Ye2WYZrdCCXL8yAX9vIR7vf77yvNTEcBCI6y4JlvZaqMB4YKVSfygs8XqGGCHjLpE5bvI-A4ESbAUX26cVFvCeDg9pR6HK7BmwPMlO96krgtKZcXEJtUELYPys6-rbwAIdmxJxKxpgRpt0FRv_9fm6YPwG7QivYBX-vRwaodL1TA"", ""alg"": ""HS256""}";
-        private readonly RsaSecurityKey _rsaKey;
+        private RsaSecurityKey _rsaKey;
 
-        public JwtRequestAuthorizeTests()
+        public async ValueTask DisposeAsync()
+        {
+            await _mockPipeline.DisposeAsync();
+        }
+
+        public async ValueTask InitializeAsync()
         {
             IdentityModelEventSource.ShowPII = true;
 
@@ -167,7 +172,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
                 }
             });
 
-            _mockPipeline.Initialize();
+            await _mockPipeline.InitializeAsync();
         }
 
         string CreateRequestJwt(string issuer, string audience, SigningCredentials credential, Claim[] claims, bool setJwtTyp = false)

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Authorize/RestrictAccessTokenViaBrowserTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Authorize/RestrictAccessTokenViaBrowserTests.cs
@@ -101,7 +101,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
 
             response.StatusCode.Should().Be(HttpStatusCode.Found);
             response.Headers.Location.AbsoluteUri.Should().StartWith("https://client1/callback");
-            var authorization = new IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+            var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
             authorization.IdentityToken.Should().NotBeNull();
             authorization.AccessToken.Should().BeNull();
         }
@@ -120,7 +120,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
 
             response.StatusCode.Should().Be(HttpStatusCode.Found);
             response.Headers.Location.AbsoluteUri.Should().StartWith("https://client1/callback");
-            var authorization = new IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+            var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
             authorization.IdentityToken.Should().NotBeNull();
             authorization.AccessToken.Should().NotBeNull();
         }
@@ -139,7 +139,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
 
             response.StatusCode.Should().Be(HttpStatusCode.Found);
             response.Headers.Location.AbsoluteUri.Should().StartWith("https://client2/callback");
-            var authorization = new IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+            var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
             authorization.IdentityToken.Should().NotBeNull();
             authorization.AccessToken.Should().BeNull();
         }
@@ -172,7 +172,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
 
             response.StatusCode.Should().Be(HttpStatusCode.Found);
             response.Headers.Location.AbsoluteUri.Should().StartWith("https://client3/callback");
-            var authorization = new IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+            var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
             authorization.IdentityToken.Should().NotBeNull();
             authorization.AccessToken.Should().BeNull();
             authorization.Code.Should().NotBeNull();
@@ -192,7 +192,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
 
             response.StatusCode.Should().Be(HttpStatusCode.Found);
             response.Headers.Location.AbsoluteUri.Should().StartWith("https://client3/callback");
-            var authorization = new IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+            var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
             authorization.IdentityToken.Should().NotBeNull();
             authorization.AccessToken.Should().NotBeNull();
             authorization.Code.Should().NotBeNull();
@@ -213,7 +213,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
 
             response.StatusCode.Should().Be(HttpStatusCode.Found);
             response.Headers.Location.AbsoluteUri.Should().StartWith("https://client4/callback");
-            var authorization = new IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+            var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
             authorization.IdentityToken.Should().NotBeNull();
             authorization.AccessToken.Should().BeNull();
             authorization.Code.Should().NotBeNull();

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Authorize/RestrictAccessTokenViaBrowserTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Authorize/RestrictAccessTokenViaBrowserTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace IdentityServer.IntegrationTests.Endpoints.Authorize
 {
-    public class RestrictAccessTokenViaBrowserTests
+    public class RestrictAccessTokenViaBrowserTests: IAsyncLifetime
     {
         private const string Category = "RestrictAccessTokenViaBrowserTests";
 
@@ -23,7 +23,12 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
 
         private ClaimsPrincipal _user = new IdentityServerUser("bob").CreatePrincipal();
 
-        public RestrictAccessTokenViaBrowserTests()
+        public async ValueTask DisposeAsync()
+        {
+            await _mockPipeline.DisposeAsync();
+        }
+
+        public async ValueTask InitializeAsync()
         {
             _mockPipeline.Clients.AddRange(new Client[] {
                 new Client
@@ -84,7 +89,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
                 new IdentityResources.OpenId()
             });
 
-            _mockPipeline.Initialize();
+            await _mockPipeline.InitializeAsync();
         }
 
         [Fact]

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Authorize/SessionIdTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Authorize/SessionIdTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -13,13 +13,18 @@ using Xunit;
 
 namespace IdentityServer.IntegrationTests.Endpoints.Authorize
 {
-    public class SessionIdTests
+    public class SessionIdTests: IAsyncLifetime
     {
         private const string Category = "SessionIdTests";
 
         private IdentityServerPipeline _mockPipeline = new IdentityServerPipeline();
 
-        public SessionIdTests()
+        public async ValueTask DisposeAsync()
+        {
+            await _mockPipeline.DisposeAsync();
+        }
+
+        public async ValueTask InitializeAsync()
         {
             _mockPipeline.Clients.AddRange(new Client[] {
                 new Client
@@ -76,7 +81,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Authorize
                 }
             });
 
-            _mockPipeline.Initialize();
+            await _mockPipeline.InitializeAsync();
         }
 
         [Fact]

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/CheckSession/CheckSessionTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/CheckSession/CheckSessionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -10,15 +10,20 @@ using Xunit;
 
 namespace IdentityServer.IntegrationTests.Endpoints.CheckSession
 {
-    public class CheckSessionTests
+    public class CheckSessionTests: IAsyncLifetime
     {
         private const string Category = "Check session endpoint";
 
         private IdentityServerPipeline _mockPipeline = new IdentityServerPipeline();
 
-        public CheckSessionTests()
+        public async ValueTask DisposeAsync()
         {
-            _mockPipeline.Initialize();
+            await _mockPipeline.DisposeAsync();
+        }
+
+        public async ValueTask InitializeAsync()
+        {
+            await _mockPipeline.InitializeAsync();
         }
 
         [Fact]

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/DeviceAuthorization/DeviceAuthorizationTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/DeviceAuthorization/DeviceAuthorizationTests.cs
@@ -6,7 +6,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.IntegrationTests.Common;
 using IdentityServer4.Models;
 using Newtonsoft.Json;

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/DeviceAuthorization/DeviceAuthorizationTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/DeviceAuthorization/DeviceAuthorizationTests.cs
@@ -14,13 +14,18 @@ using Xunit;
 
 namespace IdentityServer.IntegrationTests.Endpoints.DeviceAuthorization
 {
-    public class DeviceAuthorizationTests
+    public class DeviceAuthorizationTests: IAsyncLifetime
     {
         private const string Category = "Device authorization endpoint";
 
         private IdentityServerPipeline _mockPipeline = new IdentityServerPipeline();
 
-        public DeviceAuthorizationTests()
+        public async ValueTask DisposeAsync()
+        {
+            await _mockPipeline.DisposeAsync();
+        }
+
+        public async ValueTask InitializeAsync()
         {
             _mockPipeline.Clients.Add(new Client
             {
@@ -34,7 +39,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.DeviceAuthorization
                 new IdentityResources.OpenId()
             });
 
-            _mockPipeline.Initialize();
+            await _mockPipeline.InitializeAsync();
         }
 
         [Fact]

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
@@ -3,7 +3,7 @@
 
 
 using FluentAssertions;
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Common;
 using IdentityServer4;
 using IdentityServer4.Configuration;

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Discovery/DiscoveryEndpointTests.cs
@@ -26,8 +26,8 @@ namespace IdentityServer.IntegrationTests.Endpoints.Discovery
         [Trait("Category", Category)]
         public async Task Issuer_uri_should_be_lowercase()
         {
-            IdentityServerPipeline pipeline = new IdentityServerPipeline();
-            pipeline.Initialize("/ROOT");
+            await using var pipeline = new IdentityServerPipeline();
+            await pipeline.InitializeAsync("/ROOT");
 
             var result = await pipeline.BackChannelClient.GetAsync("HTTPS://SERVER/ROOT/.WELL-KNOWN/OPENID-CONFIGURATION");
 
@@ -42,8 +42,8 @@ namespace IdentityServer.IntegrationTests.Endpoints.Discovery
         [Trait("Category", Category)]
         public async Task when_lower_case_issuer_option_disabled_issuer_uri_should_be_preserved()
         {
-            IdentityServerPipeline pipeline = new IdentityServerPipeline();
-            pipeline.Initialize("/ROOT");
+            await using var pipeline = new IdentityServerPipeline();
+            await pipeline.InitializeAsync("/ROOT");
 
             pipeline.Options.LowerCaseIssuerUri = false;
 
@@ -68,14 +68,14 @@ namespace IdentityServer.IntegrationTests.Endpoints.Discovery
             var key = CryptoHelper.CreateECDsaSecurityKey(JsonWebKeyECTypes.P256);
             var expectedAlgorithm = SecurityAlgorithms.EcdsaSha256;
 
-            IdentityServerPipeline pipeline = new IdentityServerPipeline();
+            await using var pipeline = new IdentityServerPipeline();
             pipeline.OnPostConfigureServices += services =>
             {
                 // add key to standard RSA key
                 services.AddIdentityServerBuilder()
                     .AddSigningCredential(key, expectedAlgorithm);
             };
-            pipeline.Initialize("/ROOT");
+            await pipeline.InitializeAsync("/ROOT");
 
             var result = await pipeline.BackChannelClient.GetAsync("https://server/root/.well-known/openid-configuration");
 
@@ -96,7 +96,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Discovery
             var ecdsaKey = CryptoHelper.CreateECDsaSecurityKey(JsonWebKeyECTypes.P256);
             var parameters = ecdsaKey.ECDsa.ExportParameters(true);
 
-            IdentityServerPipeline pipeline = new IdentityServerPipeline();
+            await using var pipeline = new IdentityServerPipeline();
 
             var jsonWebKeyFromECDsa = new JsonWebKey()
             {
@@ -117,7 +117,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Discovery
                     .AddSigningCredential(jsonWebKeyFromECDsa, SecurityAlgorithms.EcdsaSha256);
             };
 
-            pipeline.Initialize("/ROOT");
+            await pipeline.InitializeAsync("/ROOT");
 
             var result = await pipeline.BackChannelClient.GetAsync("https://server/root/.well-known/openid-configuration/jwks");
 
@@ -141,8 +141,8 @@ namespace IdentityServer.IntegrationTests.Endpoints.Discovery
         [Trait("Category", Category)]
         public async Task Jwks_entries_should_contain_alg()
         {
-            IdentityServerPipeline pipeline = new IdentityServerPipeline();
-            pipeline.Initialize("/ROOT");
+            await using var pipeline = new IdentityServerPipeline();
+            await pipeline.InitializeAsync("/ROOT");
 
             var result = await pipeline.BackChannelClient.GetAsync("https://server/root/.well-known/openid-configuration/jwks");
 
@@ -170,13 +170,13 @@ namespace IdentityServer.IntegrationTests.Endpoints.Discovery
         {
             var key = CryptoHelper.CreateECDsaSecurityKey(crv);
 
-            IdentityServerPipeline pipeline = new IdentityServerPipeline();
+            await using var pipeline = new IdentityServerPipeline();
             pipeline.OnPostConfigureServices += services =>
             {
                 services.AddIdentityServerBuilder()
                     .AddSigningCredential(key, alg);
             };
-            pipeline.Initialize("/ROOT");
+            await pipeline.InitializeAsync("/ROOT");
 
             var result = await pipeline.BackChannelClient.GetAsync("https://server/root/.well-known/openid-configuration/jwks");
 
@@ -195,14 +195,14 @@ namespace IdentityServer.IntegrationTests.Endpoints.Discovery
             var ecdsaKey = CryptoHelper.CreateECDsaSecurityKey();
             var rsaKey = CryptoHelper.CreateRsaSecurityKey();
 
-            IdentityServerPipeline pipeline = new IdentityServerPipeline();
+            await using var pipeline = new IdentityServerPipeline();
             pipeline.OnPostConfigureServices += services =>
             {
                 services.AddIdentityServerBuilder()
                     .AddSigningCredential(ecdsaKey, "ES256")
                     .AddValidationKey(new SecurityKeyInfo { Key = rsaKey, SigningAlgorithm = "RS256" });
             };
-            pipeline.Initialize("/ROOT");
+            await pipeline.InitializeAsync("/ROOT");
 
             var result = await pipeline.BackChannelClient.GetAsync("https://server/root/.well-known/openid-configuration/jwks");
 
@@ -217,8 +217,8 @@ namespace IdentityServer.IntegrationTests.Endpoints.Discovery
         [Trait("Category", Category)]
         public async Task Unicode_values_in_url_should_be_processed_correctly()
         {
-            var pipeline = new IdentityServerPipeline();
-            pipeline.Initialize();
+            await using var pipeline = new IdentityServerPipeline();
+            await pipeline.InitializeAsync();
 
             var result = await pipeline.BackChannelClient.GetDiscoveryDocumentAsync(new DiscoveryDocumentRequest
             {

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/EndSession/EndSessionTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/EndSession/EndSessionTests.cs
@@ -3,6 +3,7 @@
 
 
 using System;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -12,7 +13,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.IntegrationTests.Common;
 using IdentityServer4.Models;
 using IdentityServer4.Test;
@@ -137,7 +138,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.EndSession
 
             _mockPipeline.BrowserClient.AllowAutoRedirect = false;
             var response = await _mockPipeline.BrowserClient.GetAsync(url);
-            var authorization = new IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+            var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
             var id_token = authorization.IdentityToken;
 
             response = await _mockPipeline.BrowserClient.GetAsync(IdentityServerPipeline.EndSessionEndpoint +
@@ -224,7 +225,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.EndSession
 
             _mockPipeline.BrowserClient.AllowAutoRedirect = false;
             var response = await _mockPipeline.BrowserClient.GetAsync(url);
-            var authorization = new IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+            var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
             var id_token = authorization.IdentityToken;
 
             _mockPipeline.BrowserClient.AllowAutoRedirect = true;
@@ -272,7 +273,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.EndSession
             _mockPipeline.BrowserClient.AllowAutoRedirect = false;
             var response = await _mockPipeline.BrowserClient.GetAsync(url);
 
-            var authorization = new IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+            var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
             var id_token = authorization.IdentityToken;
 
             _mockPipeline.BrowserClient.AllowAutoRedirect = true;
@@ -305,7 +306,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.EndSession
             _mockPipeline.BrowserClient.AllowAutoRedirect = false;
             var response = await _mockPipeline.BrowserClient.GetAsync(url);
 
-            var authorization = new IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+            var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
             var id_token = authorization.IdentityToken;
 
             await _mockPipeline.LoginAsync("alice");
@@ -429,7 +430,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.EndSession
                 state: "123_state",
                 nonce: "123_nonce");
             var response = await _mockPipeline.BrowserClient.GetAsync(url);
-            var authorization = new IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+            var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
             var id_token = authorization.IdentityToken;
 
             _mockPipeline.BrowserClient.AllowAutoRedirect = true;
@@ -454,7 +455,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.EndSession
                 state: "123_state",
                 nonce: "123_nonce");
             var response = await _mockPipeline.BrowserClient.GetAsync(url);
-            var authorization = new IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+            var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
             var id_token = authorization.IdentityToken;
 
             _mockPipeline.BrowserClient.AllowAutoRedirect = true;
@@ -512,7 +513,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.EndSession
                 var parts = token.Split('.');
                 parts.Length.Should().Be(3);
 
-                var bytes = Base64Url.Decode(parts[1]);
+                var bytes = Base64Url.DecodeFromChars(parts[1]);
                 var json = Encoding.UTF8.GetString(bytes);
                 var payload = JObject.Parse(json);
                 payload["iss"].ToString().Should().Be("https://server");

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/EndSession/EndSessionTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/EndSession/EndSessionTests.cs
@@ -24,14 +24,19 @@ using static IdentityServer4.IdentityServerConstants;
 
 namespace IdentityServer.IntegrationTests.Endpoints.EndSession
 {
-    public class EndSessionTests
+    public class EndSessionTests: IAsyncLifetime
     {
         private const string Category = "End session endpoint";
 
         private IdentityServerPipeline _mockPipeline = new IdentityServerPipeline();
         private Client _wsfedClient;
 
-        public EndSessionTests()
+        public async ValueTask DisposeAsync()
+        {
+            await _mockPipeline.DisposeAsync();
+        }
+
+        public async ValueTask InitializeAsync()
         {
             _mockPipeline.Clients.Add(new Client
             {
@@ -98,7 +103,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.EndSession
                 new IdentityResources.OpenId()
             });
 
-            _mockPipeline.Initialize();
+            await _mockPipeline.InitializeAsync();
         }
 
         [Fact]

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Introspection/IntrospectionTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Introspection/IntrospectionTests.cs
@@ -14,26 +14,46 @@ using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Endpoints.Introspection.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace IdentityServer.IntegrationTests.Endpoints.Introspection
 {
-    public class IntrospectionTests
+    public class IntrospectionTests: IAsyncLifetime
     {
         private const string Category = "Introspection endpoint";
         private const string IntrospectionEndpoint = "https://server/connect/introspect";
         private const string TokenEndpoint = "https://server/connect/token";
 
-        private readonly HttpClient _client;
-        private readonly HttpMessageHandler _handler;
+        private HttpClient _client;
+        private HttpMessageHandler _handler;
 
-        public IntrospectionTests()
+        private IHost _host;
+
+        public async ValueTask DisposeAsync()
         {
-            var builder = new WebHostBuilder()
-                .UseStartup<Startup>();
-            var server = new TestServer(builder);
+            _handler.Dispose();
+            await _host.StopAsync();
+            _host.Dispose();
+        }
+
+        public async ValueTask InitializeAsync()
+        {
+            _host = new HostBuilder()
+                .ConfigureWebHost(webHostBuilder =>
+                {
+                    webHostBuilder
+                        .UseTestServer() // If using TestServer
+                        //.UseContentRoot(Directory.GetCurrentDirectory())
+                        .UseStartup<Startup>();
+                    //.UseKestrel();
+                })
+                .Build();
+            await _host.StartAsync();
+
+            var server = _host.GetTestServer();
 
             _handler = server.CreateHandler();
             _client = server.CreateClient();

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Introspection/IntrospectionTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Introspection/IntrospectionTests.cs
@@ -10,7 +10,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Endpoints.Introspection.Setup;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Revocation/RevocationTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Revocation/RevocationTests.cs
@@ -8,7 +8,7 @@ using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Common;
 using IdentityServer4.Models;
 using IdentityServer4.Test;
@@ -175,7 +175,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Revocation
                 ClientSecret = scope_secret,
 
                 Token = token,
-                TokenTypeHint = IdentityModel.OidcConstants.TokenTypes.AccessToken
+                TokenTypeHint = Duende.IdentityModel.OidcConstants.TokenTypes.AccessToken
             });
 
             return response.IsError == false && response.IsActive;

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Revocation/RevocationTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Revocation/RevocationTests.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace IdentityServer.IntegrationTests.Endpoints.Revocation
 {
-    public class RevocationTests
+    public class RevocationTests: IAsyncLifetime
     {
         private const string Category = "RevocationTests endpoint";
 
@@ -29,7 +29,12 @@ namespace IdentityServer.IntegrationTests.Endpoints.Revocation
 
         private IdentityServerPipeline _mockPipeline = new IdentityServerPipeline();
 
-        public RevocationTests()
+        public async ValueTask DisposeAsync()
+        {
+            await _mockPipeline.DisposeAsync();
+        }
+
+        public async ValueTask InitializeAsync()
         {
             _mockPipeline.Clients.Add(new Client
             {
@@ -100,7 +105,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Revocation
                 }
             });
 
-            _mockPipeline.Initialize();
+            await _mockPipeline.InitializeAsync();
         }
 
         private class Tokens

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Token/TokenEndpointTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Endpoints/Token/TokenEndpointTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using IdentityServer4.Models;
 using IdentityServer4.Test;
 using Newtonsoft.Json.Linq;
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace IdentityServer.IntegrationTests.Endpoints.Token
 {
-    public class TokenEndpointTests
+    public class TokenEndpointTests: IAsyncLifetime
     {
         private const string Category = "Token endpoint";
 
@@ -24,7 +24,12 @@ namespace IdentityServer.IntegrationTests.Endpoints.Token
 
         private IdentityServerPipeline _mockPipeline = new IdentityServerPipeline();
 
-        public TokenEndpointTests()
+        public async ValueTask DisposeAsync()
+        {
+            await _mockPipeline.DisposeAsync();
+        }
+
+        public async ValueTask InitializeAsync()
         {
             _mockPipeline.Clients.Add(new Client
             {
@@ -68,7 +73,7 @@ namespace IdentityServer.IntegrationTests.Endpoints.Token
                 }
             });
 
-            _mockPipeline.Initialize();
+            await _mockPipeline.InitializeAsync();
         }
 
         [Fact]

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Extensibility/CustomProfileServiceTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Extensibility/CustomProfileServiceTests.cs
@@ -13,13 +13,18 @@ using Xunit;
 
 namespace IdentityServer.IntegrationTests.Extensibility
 {
-    public class CustomProfileServiceTests
+    public class CustomProfileServiceTests: IAsyncLifetime
     {
         private const string Category = "Authorize endpoint";
 
         private IdentityServerPipeline _mockPipeline = new IdentityServerPipeline();
 
-        public CustomProfileServiceTests()
+        public async ValueTask DisposeAsync()
+        {
+            await _mockPipeline.DisposeAsync();
+        }
+
+        public async ValueTask InitializeAsync()
         {
             _mockPipeline.OnPostConfigureServices += svcs =>
             {
@@ -45,7 +50,7 @@ namespace IdentityServer.IntegrationTests.Extensibility
                 Password = "password",
             });
 
-            _mockPipeline.Initialize();
+            await _mockPipeline.InitializeAsync();
         }
 
         [Fact]

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Extensibility/CustomProfileServiceTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Extensibility/CustomProfileServiceTests.cs
@@ -1,9 +1,9 @@
-﻿using System.Net;
+using System.Buffers.Text;
+using System.Net;
 using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
 using IdentityServer.IntegrationTests.Common;
 using IdentityServer4.Models;
 using IdentityServer4.Services;
@@ -67,12 +67,12 @@ namespace IdentityServer.IntegrationTests.Extensibility
             response.StatusCode.Should().Be(HttpStatusCode.Redirect);
             response.Headers.Location.ToString().Should().StartWith("https://client/callback");
 
-            var authorization = new IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
+            var authorization = new Duende.IdentityModel.Client.AuthorizeResponse(response.Headers.Location.ToString());
             authorization.IsError.Should().BeFalse();
             authorization.IdentityToken.Should().NotBeNull();
 
             var payload = authorization.IdentityToken.Split('.')[1];
-            var json = Encoding.UTF8.GetString(Base64Url.Decode(payload));
+            var json = Encoding.UTF8.GetString(Base64Url.DecodeFromChars(payload));
             var obj = JObject.Parse(json);
 
             obj.GetValue("foo").Should().NotBeNull();

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/IdentityServer.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
     <PackageReference Include="FluentAssertions" />
   </ItemGroup>

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Pipeline/CorsTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Pipeline/CorsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -17,13 +17,18 @@ using Xunit;
 
 namespace IdentityServer.IntegrationTests.Pipeline
 {
-    public class CorsTests
+    public class CorsTests: IAsyncLifetime
     {
         private const string Category = "CORS Integration";
 
         private IdentityServerPipeline _pipeline = new IdentityServerPipeline();
 
-        public CorsTests()
+        public async ValueTask DisposeAsync()
+        {
+            await _pipeline.DisposeAsync();
+        }
+
+        public async ValueTask InitializeAsync()
         {
             _pipeline.Clients.AddRange(new Client[] {
                 new Client
@@ -72,7 +77,7 @@ namespace IdentityServer.IntegrationTests.Pipeline
                 }
             });
 
-            _pipeline.Initialize();
+            await _pipeline.InitializeAsync();
         }
 
         [Theory]
@@ -122,7 +127,7 @@ namespace IdentityServer.IntegrationTests.Pipeline
             {
                 services.AddSingleton<ICorsPolicyService>(policy);
             };
-            _pipeline.Initialize();
+            await _pipeline.InitializeAsync();
 
             _pipeline.BackChannelClient.DefaultRequestHeaders.Add("Origin", "https://client");
             _pipeline.BackChannelClient.DefaultRequestHeaders.Add("Access-Control-Request-Method", "GET");

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Pipeline/FederatedSignoutTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Pipeline/FederatedSignoutTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -9,7 +9,7 @@ using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.IntegrationTests.Common;
 using IdentityServer4;
 using IdentityServer4.Models;

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Pipeline/FederatedSignoutTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Pipeline/FederatedSignoutTests.cs
@@ -19,14 +19,19 @@ using Xunit;
 
 namespace IdentityServer.IntegrationTests.Pipeline
 {
-    public class FederatedSignoutTests
+    public class FederatedSignoutTests: IAsyncLifetime
     {
         private const string Category = "Federated Signout";
 
         private IdentityServerPipeline _pipeline = new IdentityServerPipeline();
         private ClaimsPrincipal _user;
 
-        public FederatedSignoutTests()
+        public async ValueTask DisposeAsync()
+        {
+            await _pipeline.DisposeAsync();
+        }
+
+        public async ValueTask InitializeAsync()
         {
             _user = new IdentityServerUser("bob")
             {
@@ -63,7 +68,7 @@ namespace IdentityServer.IntegrationTests.Pipeline
                }
             });
 
-            _pipeline.Initialize();
+            await _pipeline.InitializeAsync();
         }
 
         [Fact]

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Pipeline/SubpathHosting.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Pipeline/SubpathHosting.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel.Client;
+using Duende.IdentityModel.Client;
 using IdentityServer.IntegrationTests.Common;
 using IdentityServer4.Models;
 using IdentityServer4.Test;

--- a/src/IdentityServer4/test/IdentityServer.IntegrationTests/Pipeline/SubpathHosting.cs
+++ b/src/IdentityServer4/test/IdentityServer.IntegrationTests/Pipeline/SubpathHosting.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace IdentityServer.IntegrationTests.Pipeline
 {
-    public class SubpathHosting
+    public class SubpathHosting: IAsyncLifetime
     {
         private const string Category = "Subpath endpoint";
 
@@ -22,7 +22,12 @@ namespace IdentityServer.IntegrationTests.Pipeline
 
         private Client _client1;
 
-        public SubpathHosting()
+        public async ValueTask DisposeAsync()
+        {
+            await _mockPipeline.DisposeAsync();
+        }
+
+        public async ValueTask InitializeAsync()
         {
             _mockPipeline.Clients.AddRange(new Client[] {
                 _client1 = new Client
@@ -54,7 +59,7 @@ namespace IdentityServer.IntegrationTests.Pipeline
                 new IdentityResources.Email()
             });
             
-            _mockPipeline.Initialize("/subpath");
+            await _mockPipeline.InitializeAsync("/subpath");
         }
 
         [Fact]

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Common/TestCert.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Common/TestCert.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -13,7 +13,7 @@ namespace IdentityServer.UnitTests.Common
         public static X509Certificate2 Load()
         {
             var cert = Path.Combine(System.AppContext.BaseDirectory, "identityserver_testing.pfx");
-            return new X509Certificate2(cert, "password");
+            return X509CertificateLoader.LoadPkcs12FromFile(cert, "password");
         }
 
         public static SigningCredentials LoadSigningCredentials()

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/Results/AuthorizeResultTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Endpoints/Results/AuthorizeResultTests.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer4.Configuration;
 using IdentityServer4.Endpoints.Results;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Extensions/JwtPayloadCreationTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Extensions/JwtPayloadCreationTests.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer4.Configuration;
 using IdentityServer4.Extensions;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/IdentityServer.UnitTests.csproj
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/IdentityServer.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
 
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
     <PackageReference Include="FluentAssertions" />
   </ItemGroup>

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests.cs
@@ -12,7 +12,7 @@ using IdentityServer4.Configuration;
 using IdentityServer4.Models;
 using IdentityServer4.Validation;
 using Xunit;
-using static IdentityModel.OidcConstants;
+using static Duende.IdentityModel.OidcConstants;
 
 namespace IdentityServer.UnitTests.ResponseHandling.AuthorizeInteractionResponseGenerator
 {

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Consent.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Consent.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer4.Configuration;
 using IdentityServer4.Models;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Custom.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Custom.cs
@@ -14,7 +14,7 @@ using IdentityServer4.Services;
 using IdentityServer4.Validation;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using static IdentityModel.OidcConstants;
+using static Duende.IdentityModel.OidcConstants;
 
 namespace IdentityServer.UnitTests.ResponseHandling.AuthorizeInteractionResponseGenerator
 {

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Login.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/ResponseHandling/AuthorizeInteractionResponseGenerator/AuthorizeInteractionResponseGeneratorTests_Login.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer4;
 using IdentityServer4.Configuration;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Services/Default/DefaultClaimsServiceTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Services/Default/DefaultClaimsServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer4;
 using IdentityServer4.Configuration;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Services/Default/DefaultConsentServiceTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Services/Default/DefaultConsentServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer4;
 using IdentityServer4.Extensions;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Services/Default/DefaultTokenServiceTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Services/Default/DefaultTokenServiceTests.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer4.Configuration;
 using IdentityServer4.Models;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Services/Default/NumericUserCodeServiceTests.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Services/Default/NumericUserCodeServiceTests.cs
@@ -15,8 +15,8 @@ namespace IdentityServer.UnitTests.Services.Default
             var userCode = await sut.GenerateAsync();
             var userCodeInt = int.Parse(userCode);
 
-            userCodeInt.Should().BeGreaterOrEqualTo(100000000);
-            userCodeInt.Should().BeLessOrEqualTo(999999999);
+            userCodeInt.Should().BeGreaterThanOrEqualTo(100000000);
+            userCodeInt.Should().BeLessThanOrEqualTo(999999999);
         }
     }
 }

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AccessTokenValidation.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AccessTokenValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -7,7 +7,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4.Configuration;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_Code.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_Code.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using System.Collections.Specialized;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4.Configuration;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_IdToken.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_IdToken.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using System.Collections.Specialized;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4.Configuration;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_Invalid.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_Invalid.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using System.Collections.Specialized;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4.Configuration;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_Token.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_Token.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using System.Collections.Specialized;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4.Configuration;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_Valid.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_Valid.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using System.Collections.Specialized;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4.Configuration;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_CustomValidator.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_CustomValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Specialized;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4.Validation;
 using Xunit;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Invalid.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Invalid.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Specialized;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4;
 using Xunit;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_PKCE.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_PKCE.cs
@@ -5,7 +5,7 @@
 using System.Collections.Specialized;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4.Configuration;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Valid.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/AuthorizeRequest Validation/Authorize_ProtocolValidation_Valid.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -6,7 +6,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4;
 using Xunit;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/DeviceAuthorizationRequestValidation.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/DeviceAuthorizationRequestValidation.cs
@@ -7,7 +7,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4;
 using IdentityServer4.Models;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/DeviceCodeValidation.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/DeviceCodeValidation.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4;
 using IdentityServer4.Models;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/IdentityTokenValidation.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/IdentityTokenValidation.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using System.IdentityModel.Tokens.Jwt;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Validation.Setup;
 using Xunit;
 

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/RevocationRequestValidation.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/RevocationRequestValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer4;
 using IdentityServer4.Models;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/Secrets/PrivateKeyJwtSecretValidation.cs
@@ -8,7 +8,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer.UnitTests.Services.Default;
 using IdentityServer.UnitTests.Validation.Setup;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/Setup/TokenFactory.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/Setup/TokenFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer4.Models;
 

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_ClientCredentials_Invalid.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_ClientCredentials_Invalid.cs
@@ -6,7 +6,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4.Stores;
 using Xunit;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_Code_Invalid.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_Code_Invalid.cs
@@ -8,7 +8,7 @@ using System.Collections.Specialized;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_DeviceCode_Invalid.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_DeviceCode_Invalid.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Specialized;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_ExtensionGrants_Invalid.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_ExtensionGrants_Invalid.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using System.Collections.Specialized;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4.Stores;
 using Xunit;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_General_Invalid.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_General_Invalid.cs
@@ -7,7 +7,7 @@ using System.Collections.Specialized;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4;
 using IdentityServer4.Models;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_PKCE.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_PKCE.cs
@@ -1,14 +1,15 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using System;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4;
@@ -321,7 +322,7 @@ namespace IdentityServer.UnitTests.Validation.TokenRequest_Validation
         {
             var codeVerifierBytes = Encoding.ASCII.GetBytes(codeVerifier);
             var hashedBytes = codeVerifierBytes.Sha256();
-            var transformedCodeVerifier = Base64Url.Encode(hashedBytes);
+            var transformedCodeVerifier = Base64Url.EncodeToString(hashedBytes);
 
             return transformedCodeVerifier;
         }

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_RefreshToken_Invalid.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_RefreshToken_Invalid.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
@@ -8,7 +8,7 @@ using System.Collections.Specialized;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4.Configuration;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_ResourceOwner_Invalid.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_ResourceOwner_Invalid.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using System.Collections.Specialized;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Common;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4.Models;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_Valid.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_Valid.cs
@@ -8,7 +8,7 @@ using System.Collections.Specialized;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4;
 using IdentityServer4.Models;

--- a/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/UserInfoRequestValidation.cs
+++ b/src/IdentityServer4/test/IdentityServer.UnitTests/Validation/UserInfoRequestValidation.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
 using FluentAssertions;
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer.UnitTests.Validation.Setup;
 using IdentityServer4.Stores;
 using IdentityServer4.Validation;

--- a/src/Storage/build/build.csproj
+++ b/src/Storage/build/build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Storage/src/IdentityServer4.Storage.csproj
+++ b/src/Storage/src/IdentityServer4.Storage.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <PackageId>IdentityServer4.NET.Storage</PackageId>
     <Description>Storage interfaces and models for IdentityServer4</Description>

--- a/src/Storage/src/IdentityServer4.Storage.csproj
+++ b/src/Storage/src/IdentityServer4.Storage.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityModel" />
+    <PackageReference Include="Duende.IdentityModel" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Storage/src/IdentityServerUser.cs
+++ b/src/Storage/src/IdentityServerUser.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using IdentityServer4.Extensions;
 using System;
 using System.Collections.Generic;

--- a/src/Storage/src/Models/Token.cs
+++ b/src/Storage/src/Models/Token.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
+// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Storage/src/Stores/Serialization/ClaimsPrincipalConverter.cs
+++ b/src/Storage/src/Stores/Serialization/ClaimsPrincipalConverter.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 
-using IdentityModel;
+using Duende.IdentityModel;
 using System;
 using System.Linq;
 using System.Security.Claims;

--- a/src/build/Program.Partial.cs
+++ b/src/build/Program.Partial.cs
@@ -17,6 +17,7 @@ namespace build
         {
             public const string CleanBuildOutput = "clean-build-output";
             public const string CleanPackOutput = "clean-pack-output";
+			public const string CleanDotnetOutput = "clean-dotnet-output";
             public const string Build = "build";
             public const string Test = "test";
             public const string Pack = "pack";
@@ -27,22 +28,27 @@ namespace build
 
         static async Task Main(string[] args)
         {
+			Target(Targets.CleanDotnetOutput, () =>
+            {
+                Run("dotnet", "clean -c Release -v m --nologo", echoPrefix: Prefix);
+            });
+			
             Target(Targets.CleanBuildOutput, () =>
             {
                 //Run("dotnet", "clean -c Release -v m --nologo", echoPrefix: Prefix);
             });
 
-            Target(Targets.Build, DependsOn(Targets.CleanBuildOutput), () =>
+            Target(Targets.Build, dependsOn: [Targets.CleanBuildOutput], () =>
             {
                 Run("dotnet", "build -c Release --nologo", echoPrefix: Prefix);
             });
 
-            Target(Targets.SignBinary, DependsOn(Targets.Build), () =>
+            Target(Targets.SignBinary, dependsOn: [Targets.Build], () =>
             {
                 Sign("./src/bin/Release", "*.dll");
             });
 
-            Target(Targets.Test, DependsOn(Targets.Build), () =>
+            Target(Targets.Test, dependsOn: [Targets.Build], () =>
             {
                 Run("dotnet", $"test -c Release --no-build", echoPrefix: Prefix);
             });
@@ -55,19 +61,19 @@ namespace build
                 }
             });
 
-            Target(Targets.Pack, DependsOn(Targets.Build, Targets.CleanPackOutput), () =>
+            Target(Targets.Pack, dependsOn: [Targets.Build, Targets.CleanPackOutput], () =>
             {
                 var project = Directory.GetFiles("./src", "*.csproj", SearchOption.TopDirectoryOnly).OrderBy(_ => _).First();
 
                 Run("dotnet", $"pack {project} -c Release -o \"{Directory.CreateDirectory(packOutput).FullName}\" --no-build --nologo", echoPrefix: Prefix);
             });
 
-            Target(Targets.SignPackage, DependsOn(Targets.Pack), () =>
+            Target(Targets.SignPackage, dependsOn: [Targets.Pack], () =>
             {
                 Sign(packOutput, "*.nupkg");
             });
 
-            Target(Targets.CopyPackOutput, DependsOn(Targets.Pack), () =>
+            Target(Targets.CopyPackOutput, dependsOn: [Targets.Pack], () =>
             {
                 Directory.CreateDirectory(packOutputCopy);
 
@@ -77,11 +83,11 @@ namespace build
                 }
             });
 
-            Target("quick", DependsOn(Targets.CopyPackOutput));
+            Target("quick", dependsOn: [Targets.CopyPackOutput]);
 
-            Target("default", DependsOn(Targets.Test, Targets.CopyPackOutput));
+            Target("default", dependsOn: [Targets.Test, Targets.CopyPackOutput]);
 
-            Target("sign", DependsOn(Targets.SignBinary, Targets.Test, Targets.SignPackage, Targets.CopyPackOutput));
+            Target("sign", dependsOn: [Targets.SignBinary, Targets.Test, Targets.SignPackage, Targets.CopyPackOutput]);
 
             await RunTargetsAndExitAsync(args, ex => ex is SimpleExec.ExitCodeException || ex.Message.EndsWith(envVarMissing), () => Prefix);
         }


### PR DESCRIPTION
Prepare new version for .NET 10.
Includes:
- Update Runtime Framework to .NET 10
- Update all 3rd party dependencies 
- Migrate from IdentityModel to Duende.IdentyModel
  IdentityModel no longer exist and has been replaced with Duende.IdentityModel under Apache 2 license.
- Fix usage of obsolete APIs
- Remove all build warnings.